### PR TITLE
docs: update broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gluesql-js` has been moved to the GlueSQL main repo
 ## Link
-https://github.com/gluesql/gluesql/tree/main/gluesql-js
+https://github.com/gluesql/gluesql/tree/main/pkg/javascript
 
 
 ---


### PR DESCRIPTION
the link before used the old url. this should be done before #3.