### PR TITLE
Clean up clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ impl Glue {
             let mut payloads = vec![];
             let mut storage = cell.replace(None).unwrap();
 
-            for query in queries.iter() {
+            for query in &queries {
                 let statement = translate(query);
                 let statement = match statement {
                     Ok(statement) => statement,
@@ -176,7 +176,7 @@ impl Glue {
 
                         return Err(error);
                     }
-                };
+                }
             }
 
             cell.replace(Some(storage));

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -24,7 +24,7 @@ fn convert_payload(payload: Payload) -> Json {
                 .map(|values| {
                     let row = labels
                         .iter()
-                        .zip(values.into_iter())
+                        .zip(values)
                         .map(|(label, value)| {
                             let key = label.to_owned();
                             let value = Json::try_from(value).unwrap();

--- a/storages/idb-storage/src/convert.rs
+++ b/storages/idb-storage/src/convert.rs
@@ -12,7 +12,7 @@ use {
     wasm_bindgen::JsValue,
 };
 
-pub fn convert(value: JsValue, column_defs: Option<&[ColumnDef]>) -> Result<DataRow> {
+pub fn convert(value: &JsValue, column_defs: Option<&[ColumnDef]>) -> Result<DataRow> {
     let value: JsonValue = value.into_serde().err_into()?;
 
     match (value, column_defs) {

--- a/storages/idb-storage/src/lib.rs
+++ b/storages/idb-storage/src/lib.rs
@@ -37,6 +37,16 @@ impl<T> SendWrapperExt for T {}
 const SCHEMA_STORE: &str = "gluesql-schema";
 const DEFAULT_NAMESPACE: &str = "gluesql";
 
+fn record_upgrade_error(error: &Mutex<Option<Error>>, e: Error) {
+    let Ok(mut error) = error.lock() else {
+        let msg = JsValue::from_str("infallible - lock acquire failed");
+        console::error_1(&msg);
+        return;
+    };
+
+    *error = Some(e);
+}
+
 enum AlterType {
     InsertSchema,
     DeleteSchema,
@@ -61,16 +71,7 @@ impl IdbStorage {
                 let database = match event.database().err_into() {
                     Ok(database) => database,
                     Err(e) => {
-                        let mut error = match error.lock() {
-                            Ok(error) => error,
-                            Err(_) => {
-                                let msg = JsValue::from_str("infallible - lock acquire failed");
-                                console::error_1(&msg);
-                                return;
-                            }
-                        };
-
-                        *error = Some(e);
+                        record_upgrade_error(&error, e);
                         return;
                     }
                 };
@@ -79,16 +80,7 @@ impl IdbStorage {
                     .create_object_store(SCHEMA_STORE, ObjectStoreParams::new())
                     .err_into()
                 {
-                    let mut error = match error.lock() {
-                        Ok(error) => error,
-                        Err(_) => {
-                            let msg = JsValue::from_str("infallible - lock acquire failed");
-                            console::error_1(&msg);
-                            return;
-                        }
-                    };
-
-                    *error = Some(e);
+                    record_upgrade_error(&error, e);
                 }
             });
 
@@ -139,16 +131,7 @@ impl IdbStorage {
                 let database = match event.database().err_into() {
                     Ok(database) => database,
                     Err(e) => {
-                        let mut error = match error.lock() {
-                            Ok(error) => error,
-                            Err(_) => {
-                                let msg = JsValue::from_str("infallible - lock acquire failed");
-                                console::error_1(&msg);
-                                return;
-                            }
-                        };
-
-                        *error = Some(e);
+                        record_upgrade_error(&error, e);
                         return;
                     }
                 };
@@ -171,24 +154,12 @@ impl IdbStorage {
                         {
                             return;
                         }
-                        database
-                            .delete_object_store(table_name.as_str())
-                            .err_into()
-                            .map(|_| ())
+                        database.delete_object_store(table_name.as_str()).err_into()
                     }
                 };
 
                 if let Err(e) = err {
-                    let mut error = match error.lock() {
-                        Ok(error) => error,
-                        Err(_) => {
-                            let msg = JsValue::from_str("infallible - lock acquire failed");
-                            console::error_1(&msg);
-                            return;
-                        }
-                    };
-
-                    *error = Some(e);
+                    record_upgrade_error(&error, e);
                 }
             });
 
@@ -306,7 +277,7 @@ impl Store for IdbStorage {
             .await
             .err_into()?;
         let row = row
-            .map(|row| convert(row, column_defs.as_deref()))
+            .map(|row| convert(&row, column_defs.as_deref()))
             .transpose()?;
 
         transaction
@@ -368,7 +339,7 @@ impl Store for IdbStorage {
                 let key: JsonValue = key_js.into_serde().err_into()?;
                 let key: Key = Value::try_from(key)?.try_into()?;
 
-                let row = convert(row_js, column_defs.as_deref())?;
+                let row = convert(&row_js, column_defs.as_deref())?;
 
                 rows.push((key, row));
             }
@@ -410,7 +381,7 @@ impl StoreMut for IdbStorage {
             .is_some();
 
         if !schema_exists {
-            self.alter_object_store(schema.table_name.to_owned(), AlterType::InsertSchema)
+            self.alter_object_store(schema.table_name.clone(), AlterType::InsertSchema)
                 .await?;
         }
 
@@ -441,7 +412,7 @@ impl StoreMut for IdbStorage {
                 .send_wrapper()
                 .await
                 .err_into()?;
-        };
+        }
 
         transaction
             .take()

--- a/storages/idb-storage/tests/convert.rs
+++ b/storages/idb-storage/tests/convert.rs
@@ -51,7 +51,7 @@ async fn convert_schema() {
         Value::Bool(true),
     ]);
     assert_eq!(
-        convert(actual_data, Some(actual_defs.as_slice())),
+        convert(&actual_data, Some(actual_defs.as_slice())),
         Ok(expected)
     );
 }
@@ -73,5 +73,5 @@ async fn convert_schemaless() {
         .into_iter()
         .collect(),
     );
-    assert_eq!(convert(actual, None), Ok(expected));
+    assert_eq!(convert(&actual, None), Ok(expected));
 }

--- a/storages/web-storage/src/lib.rs
+++ b/storages/web-storage/src/lib.rs
@@ -94,19 +94,16 @@ impl Store for WebStorage {
 
         table_names
             .iter()
-            .filter_map(|table_name| {
-                self.get(format!("{}/{}", SCHEMA_PATH, table_name))
-                    .transpose()
-            })
+            .filter_map(|table_name| self.get(format!("{SCHEMA_PATH}/{table_name}")).transpose())
             .collect::<Result<Vec<_>>>()
     }
 
     async fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>> {
-        self.get(format!("{}/{}", SCHEMA_PATH, table_name))
+        self.get(format!("{SCHEMA_PATH}/{table_name}"))
     }
 
     async fn fetch_data(&self, table_name: &str, target: &Key) -> Result<Option<DataRow>> {
-        let path = format!("{}/{}", DATA_PATH, table_name);
+        let path = format!("{DATA_PATH}/{table_name}");
         let row = self
             .get::<Vec<(Key, DataRow)>>(path)?
             .unwrap_or_default()
@@ -117,10 +114,10 @@ impl Store for WebStorage {
     }
 
     async fn scan_data<'a>(&'a self, table_name: &str) -> Result<RowIter<'a>> {
-        let path = format!("{}/{}", DATA_PATH, table_name);
+        let path = format!("{DATA_PATH}/{table_name}");
         let mut rows = self.get::<Vec<(Key, DataRow)>>(path)?.unwrap_or_default();
 
-        match self.get(format!("{}/{}", SCHEMA_PATH, table_name))? {
+        match self.get(format!("{SCHEMA_PATH}/{table_name}"))? {
             Some(Schema {
                 column_defs: Some(column_defs),
                 ..
@@ -147,7 +144,7 @@ impl StoreMut for WebStorage {
         table_names.push(schema.table_name.clone());
 
         self.set(TABLE_NAMES_PATH, table_names)?;
-        self.set(format!("{}/{}", SCHEMA_PATH, schema.table_name), schema)
+        self.set(format!("{SCHEMA_PATH}/{}", schema.table_name), schema)
     }
 
     async fn delete_schema(&mut self, table_name: &str) -> Result<()> {
@@ -158,13 +155,13 @@ impl StoreMut for WebStorage {
             .map(|i| table_names.remove(i));
 
         self.set(TABLE_NAMES_PATH, table_names)?;
-        self.delete(format!("{}/{}", SCHEMA_PATH, table_name));
-        self.delete(format!("{}/{}", DATA_PATH, table_name));
+        self.delete(format!("{SCHEMA_PATH}/{table_name}"));
+        self.delete(format!("{DATA_PATH}/{table_name}"));
         Ok(())
     }
 
     async fn append_data(&mut self, table_name: &str, new_rows: Vec<DataRow>) -> Result<()> {
-        let path = format!("{}/{}", DATA_PATH, table_name);
+        let path = format!("{DATA_PATH}/{table_name}");
         let rows = self.get::<Vec<(Key, DataRow)>>(&path)?.unwrap_or_default();
         let new_rows = new_rows.into_iter().map(|row| {
             let key = Key::Uuid(Uuid::new_v4().as_u128());
@@ -178,10 +175,10 @@ impl StoreMut for WebStorage {
     }
 
     async fn insert_data(&mut self, table_name: &str, new_rows: Vec<(Key, DataRow)>) -> Result<()> {
-        let path = format!("{}/{}", DATA_PATH, table_name);
+        let path = format!("{DATA_PATH}/{table_name}");
         let mut rows = self.get::<Vec<(Key, DataRow)>>(&path)?.unwrap_or_default();
 
-        for (key, row) in new_rows.into_iter() {
+        for (key, row) in new_rows {
             if let Some(i) = rows.iter().position(|(k, _)| k == &key) {
                 rows[i] = (key, row);
             } else {
@@ -193,10 +190,10 @@ impl StoreMut for WebStorage {
     }
 
     async fn delete_data(&mut self, table_name: &str, keys: Vec<Key>) -> Result<()> {
-        let path = format!("{}/{}", DATA_PATH, table_name);
+        let path = format!("{DATA_PATH}/{table_name}");
         let mut rows = self.get::<Vec<(Key, DataRow)>>(&path)?.unwrap_or_default();
 
-        for key in keys.iter() {
+        for key in &keys {
             if let Some(i) = rows.iter().position(|(k, _)| k == key) {
                 rows.remove(i);
             }


### PR DESCRIPTION
## Summary

- clean up pedantic clippy warnings in the JavaScript workspace
- consolidate repeated IndexedDB upgrade error recording logic
- update IndexedDB conversion to borrow `JsValue` instead of taking it by value

## Verification

- `cargo fmt --all --check`
- `cargo check --workspace --target wasm32-unknown-unknown --locked`
- `cargo clippy --workspace --target wasm32-unknown-unknown --locked --all-targets`
- `wasm-pack test --headless --firefox`