### PR TITLE
Add worker-based OPFS entry point scaffolding

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -34,11 +34,17 @@ jobs:
       - name: Check Node.js binding
         run: cargo check -p gluesql-js --no-default-features --features nodejs --locked
 
+      - name: Check OPFS binding
+        run: cargo check -p gluesql-js --features opfs --target wasm32-unknown-unknown --locked
+
       - name: Run clippy
         run: cargo clippy --workspace --target wasm32-unknown-unknown --locked --all-targets
 
       - name: Run Node.js binding clippy
         run: cargo clippy -p gluesql-js --no-default-features --features nodejs --locked --all-targets
+
+      - name: Run OPFS binding clippy
+        run: cargo clippy -p gluesql-js --features opfs --target wasm32-unknown-unknown --locked --all-targets
 
   js_build:
     name: Web build
@@ -61,6 +67,9 @@ jobs:
 
       - name: Build web package
         run: npm run build:web
+
+      - name: Build OPFS package
+        run: npm run build:opfs
 
   js_node_tests:
     name: Node.js (${{ matrix.target }})
@@ -117,6 +126,9 @@ jobs:
 
       - name: Test JavaScript package
         run: wasm-pack test --headless --firefox . -p gluesql-js
+
+      - name: Test OPFS package
+        run: wasm-pack test --headless --firefox . -p gluesql-js --features opfs --test opfs
 
   js_storage_tests:
     name: Storage tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist_web/
+dist_opfs/
 dist_nodejs/
 dist/
 node_modules/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 nodejs = []
+opfs = []
 
 [dependencies]
 gluesql-core.workspace = true

--- a/examples/web/opfs/index.html
+++ b/examples/web/opfs/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>GlueSQL OPFS example</title>
+    <script type="module">
+      import { gluesql } from '../../../gluesql.opfs.js';
+
+      const showError = (message) => {
+        document.querySelector('#status').textContent = `FAILED: ${message}`;
+      };
+      window.addEventListener('error', (e) => showError(e.message));
+      window.addEventListener('unhandledrejection', (e) => showError(String(e.reason)));
+
+      async function run() {
+        const db = gluesql();
+
+        try {
+          const result = await db.query(`
+            DROP TABLE IF EXISTS Foo;
+            CREATE TABLE Foo (id INTEGER, name TEXT);
+            INSERT INTO Foo VALUES (1, 'hello'), (2, 'worker');
+            SELECT * FROM Foo;
+          `);
+
+          for (const item of result) {
+            const node = document.createElement('code');
+
+            node.textContent = [
+              `type: ${item.type}`,
+              item.affected !== undefined ? `affected: ${item.affected}` : '',
+              item.rows ? `rows: ${JSON.stringify(item.rows)}` : '',
+            ].filter(Boolean).join(' | ');
+
+            document.querySelector('#box').append(node);
+          }
+
+          document.querySelector('#status').textContent = 'OK: query ran inside the worker';
+        } catch (error) {
+          document.querySelector('#status').textContent = `FAILED: ${error.message}`;
+        }
+      }
+
+      run();
+    </script>
+    <style>
+      body { padding: 0; margin: 0; }
+      #box {
+        display: flex;
+        flex-direction: column;
+        padding: 20px;
+        background-color: #222;
+        color: white;
+        min-height: 100vh;
+        box-sizing: border-box;
+      }
+      code {
+        margin: 5px;
+        padding: 10px;
+        font-family: monospace;
+        border: 1px solid white;
+      }
+      #status { font-family: monospace; padding: 10px 5px; }
+    </style>
+  </head>
+  <body>
+    <div id="box">
+      <div id="status">loading...</div>
+    </div>
+  </body>
+</html>

--- a/examples/web/opfs/lifecycle-repro.html
+++ b/examples/web/opfs/lifecycle-repro.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html>
+  <body>
+    <pre id="result">running...</pre>
+
+    <script type="module">
+      import { gluesql } from '../../../gluesql.opfs.js';
+
+      const settlesAs = (promise, timeoutMs = 250) =>
+        Promise.race([
+          promise.then(
+            () => 'resolved',
+            () => 'rejected',
+          ),
+          new Promise((resolve) =>
+            setTimeout(() => resolve('pending'), timeoutMs),
+          ),
+        ]);
+
+      // A normal query error is handled without stopping the worker.
+      const queryErrorDb = gluesql();
+      let queryError;
+
+      try {
+        await queryErrorDb.query('SELECT * FROM Missing');
+      } catch (error) {
+        queryError = error.message;
+      } finally {
+        queryErrorDb.terminate();
+      }
+
+      // Terminate while a request is in flight.
+      const terminated = gluesql();
+      const inFlight = terminated.query('SELECT 1');
+
+      terminated.terminate();
+
+      const inFlightAfterTerminate =
+        await settlesAs(inFlight);
+      const queryAfterTerminate =
+        await settlesAs(terminated.query('SELECT 2'));
+
+      // Simulate a missing or incorrectly packaged worker asset.
+      const failed = gluesql(
+        new URL('./missing-worker.js', import.meta.url),
+      );
+
+      const initialWorkerFailure = await settlesAs(
+        failed.query('SELECT 1'),
+        5_000,
+      );
+      const queryAfterWorkerFailure = await settlesAs(
+        failed.query('SELECT 2'),
+      );
+
+      failed.terminate();
+
+      const result = {
+        queryError,
+        inFlightAfterTerminate,
+        queryAfterTerminate,
+        initialWorkerFailure,
+        queryAfterWorkerFailure,
+      };
+
+      document.querySelector('#result').textContent =
+        JSON.stringify(result, null, 2);
+    </script>
+  </body>
+</html>

--- a/gluesql.opfs.js
+++ b/gluesql.opfs.js
@@ -1,0 +1,45 @@
+export function gluesql(workerUrl = new URL('./gluesql.opfs.worker.js', import.meta.url)) {
+  const worker = new Worker(workerUrl, { type: 'module' });
+  const pending = new Map();
+  let nextId = 0;
+
+  worker.onmessage = ({ data }) => {
+    const { id, result, error } = data;
+    const request = pending.get(id);
+
+    if (!request) {
+      return;
+    }
+
+    pending.delete(id);
+
+    if (error === undefined) {
+      request.resolve(result);
+    } else {
+      request.reject(new Error(error));
+    }
+  };
+
+  worker.onerror = (event) => {
+    for (const { reject } of pending.values()) {
+      reject(new Error(event.message ?? 'worker error'));
+    }
+
+    pending.clear();
+  };
+
+  return {
+    query(sql) {
+      return new Promise((resolve, reject) => {
+        const id = nextId;
+        nextId += 1;
+
+        pending.set(id, { resolve, reject });
+        worker.postMessage({ id, sql });
+      });
+    },
+    terminate() {
+      worker.terminate();
+    },
+  };
+}

--- a/gluesql.opfs.js
+++ b/gluesql.opfs.js
@@ -2,6 +2,24 @@ export function gluesql(workerUrl = new URL('./gluesql.opfs.worker.js', import.m
   const worker = new Worker(workerUrl, { type: 'module' });
   const pending = new Map();
   let nextId = 0;
+  let terminalError = null;
+
+  // Once the worker can no longer respond (load failure or termination),
+  // reject everything in flight and remember the error so later calls
+  // fail immediately instead of waiting forever.
+  const fail = (error) => {
+    if (terminalError !== null) {
+      return;
+    }
+
+    terminalError = error;
+
+    for (const { reject } of pending.values()) {
+      reject(error);
+    }
+
+    pending.clear();
+  };
 
   worker.onmessage = ({ data }) => {
     const { id, result, error } = data;
@@ -21,15 +39,15 @@ export function gluesql(workerUrl = new URL('./gluesql.opfs.worker.js', import.m
   };
 
   worker.onerror = (event) => {
-    for (const { reject } of pending.values()) {
-      reject(new Error(event.message ?? 'worker error'));
-    }
-
-    pending.clear();
+    fail(new Error(event.message ?? 'worker error'));
   };
 
   return {
     query(sql) {
+      if (terminalError !== null) {
+        return Promise.reject(terminalError);
+      }
+
       return new Promise((resolve, reject) => {
         const id = nextId;
         nextId += 1;
@@ -40,6 +58,7 @@ export function gluesql(workerUrl = new URL('./gluesql.opfs.worker.js', import.m
     },
     terminate() {
       worker.terminate();
+      fail(new Error('worker terminated'));
     },
   };
 }

--- a/gluesql.opfs.worker.js
+++ b/gluesql.opfs.worker.js
@@ -1,0 +1,21 @@
+import init, { Glue } from './dist_opfs/gluesql_js.js';
+
+let glue = null;
+
+const ready = init().then(() => {
+  glue = new Glue();
+});
+
+self.onmessage = async ({ data }) => {
+  const { id, sql } = data;
+
+  try {
+    await ready;
+
+    const result = await glue.query(sql);
+
+    self.postMessage({ id, result });
+  } catch (error) {
+    self.postMessage({ id, error: String(error) });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "npm run build:web && npm run build:node",
     "build:web": "wasm-pack build --no-pack --target web --no-typescript --release --out-dir ./dist_web",
+    "build:opfs": "wasm-pack build --no-pack --target web --no-typescript --release --out-dir ./dist_opfs -- --features opfs",
     "build:node": "napi build --release --platform --js gluesql.native.js --dts gluesql.native.d.ts --no-default-features --features nodejs",
     "test:node": "node tests/nodejs.js"
   },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,17 @@ mod node;
 #[cfg(target_arch = "wasm32")]
 mod utils;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(feature = "opfs")))]
 mod wasm;
+
+#[cfg(all(target_arch = "wasm32", feature = "opfs"))]
+mod opfs;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use node::Glue;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(feature = "opfs")))]
 pub use wasm::Glue;
+
+#[cfg(all(target_arch = "wasm32", feature = "opfs"))]
+pub use opfs::Glue;

--- a/src/opfs.rs
+++ b/src/opfs.rs
@@ -1,0 +1,46 @@
+use {
+    crate::{payload::convert_to_js_value, utils},
+    gluesql_core::prelude::Glue as CoreGlue,
+    gluesql_memory_storage::MemoryStorage,
+    js_sys::Promise,
+    wasm_bindgen::prelude::*,
+};
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn debug(s: &str);
+}
+
+#[wasm_bindgen]
+pub struct Glue {
+    inner: CoreGlue<MemoryStorage>,
+}
+
+impl Default for Glue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[allow(clippy::unused_unit)]
+#[wasm_bindgen]
+impl Glue {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        utils::set_panic_hook();
+
+        debug("[GlueSQL] opfs build loaded (scaffolding storage: memory)");
+
+        Self {
+            inner: CoreGlue::new(MemoryStorage::default()),
+        }
+    }
+
+    pub fn query(&mut self, sql: String) -> Promise {
+        match self.inner.execute(sql) {
+            Ok(payloads) => Promise::resolve(&convert_to_js_value(payloads)),
+            Err(error) => Promise::reject(&JsValue::from_str(&error.to_string())),
+        }
+    }
+}

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    target_arch = "wasm32",
-    not(feature = "nodejs"),
-    not(feature = "opfs")
-))]
+#![cfg(all(target_arch = "wasm32", not(feature = "nodejs"), not(feature = "opfs")))]
 
 wasm_bindgen_test_configure!(run_in_browser);
 

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,4 +1,8 @@
-#![cfg(all(target_arch = "wasm32", not(feature = "nodejs")))]
+#![cfg(all(
+    target_arch = "wasm32",
+    not(feature = "nodejs"),
+    not(feature = "opfs")
+))]
 
 wasm_bindgen_test_configure!(run_in_browser);
 

--- a/tests/join_multiple_storages.rs
+++ b/tests/join_multiple_storages.rs
@@ -1,8 +1,4 @@
-#![cfg(all(
-    target_arch = "wasm32",
-    not(feature = "nodejs"),
-    not(feature = "opfs")
-))]
+#![cfg(all(target_arch = "wasm32", not(feature = "nodejs"), not(feature = "opfs")))]
 
 wasm_bindgen_test_configure!(run_in_browser);
 

--- a/tests/join_multiple_storages.rs
+++ b/tests/join_multiple_storages.rs
@@ -1,4 +1,8 @@
-#![cfg(all(target_arch = "wasm32", not(feature = "nodejs")))]
+#![cfg(all(
+    target_arch = "wasm32",
+    not(feature = "nodejs"),
+    not(feature = "opfs")
+))]
 
 wasm_bindgen_test_configure!(run_in_browser);
 

--- a/tests/opfs.rs
+++ b/tests/opfs.rs
@@ -1,0 +1,55 @@
+#![cfg(all(target_arch = "wasm32", feature = "opfs"))]
+
+wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+use {
+    gloo_utils::format::JsValueSerdeExt,
+    gluesql_js::Glue,
+    serde_json::{Value as Json, json},
+    wasm_bindgen_futures::JsFuture,
+    wasm_bindgen_test::*,
+};
+
+#[wasm_bindgen_test]
+async fn queries() {
+    let mut glue = Glue::new();
+
+    let sql = "
+        CREATE TABLE Foo (id INTEGER, name TEXT);
+        INSERT INTO Foo VALUES (1, 'hello'), (2, 'worker');
+        SELECT * FROM Foo ORDER BY id;
+    ";
+    let actual: Json = JsFuture::from(glue.query(sql.to_owned()))
+        .await
+        .unwrap()
+        .into_serde()
+        .unwrap();
+    let expected = json!([
+        { "type": "CREATE TABLE" },
+        { "type": "INSERT", "affected": 2 },
+        {
+            "type": "SELECT",
+            "rows": [
+                { "id": 1, "name": "hello" },
+                { "id": 2, "name": "worker" },
+            ],
+        },
+    ]);
+    assert_eq!(actual, expected);
+}
+
+#[wasm_bindgen_test]
+async fn error() {
+    let mut glue = Glue::new();
+
+    let error = JsFuture::from(glue.query("SELECT * FROM Missing".to_owned()))
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .as_string()
+            .unwrap()
+            .contains("table not found: Missing")
+    );
+}


### PR DESCRIPTION
Add worker-based OPFS entry point scaffolding

Set up the worker-based entry point proposed in #10, ahead of the
opfs-storage crate:

- `opfs` cargo feature with a dedicated binding (`src/opfs.rs`), keeping
  the existing browser entry point untouched
- `gluesql.opfs.js` main-thread proxy exposing a Promise-based `query()`
  over postMessage RPC, and `gluesql.opfs.worker.js` worker host
- `build:opfs` script producing a separate `dist_opfs` build
- worker-context tests (`run_in_dedicated_worker`) and CI coverage for
  check, clippy, build, and test
- gate `error` and `join_multiple_storages` tests out of the opfs build,
  which has no WebStorage engines

MemoryStorage backs the entry point as internal test scaffolding until
the opfs-storage crate lands; it is not exposed publicly.

Part of #10