### PR TITLE
Add Playwright tests for worker proxy functionality

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -130,6 +130,34 @@ jobs:
       - name: Test OPFS package
         run: wasm-pack test --headless --firefox . -p gluesql-js --features opfs --test opfs
 
+  js_proxy_tests:
+    name: Worker proxy tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm install --no-package-lock
+
+      - name: Set up wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: "v0.13.1"
+
+      - name: Build OPFS package
+        run: npm run build:opfs
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run worker proxy tests
+        run: npm run test:browser
+
   js_storage_tests:
     name: Storage tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ index.d.ts
 **/*.rs.bk
 wasm-pack.log
 package-lock.json
+playwright-report/
+test-results/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:web": "wasm-pack build --no-pack --target web --no-typescript --release --out-dir ./dist_web",
     "build:opfs": "wasm-pack build --no-pack --target web --no-typescript --release --out-dir ./dist_opfs -- --features opfs",
     "build:node": "napi build --release --platform --js gluesql.native.js --dts gluesql.native.d.ts --no-default-features --features nodejs",
-    "test:node": "node tests/nodejs.js"
+    "test:node": "node tests/nodejs.js",
+    "test:browser": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -62,6 +63,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.7.1",
+    "@playwright/test": "^1.62.0",
     "wasm-pack": "^0.13.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,21 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests/browser',
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: 'http://127.0.0.1:8765',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'python3 -m http.server 8765 --bind 127.0.0.1',
+    url: 'http://127.0.0.1:8765/',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/browser/fixtures/blank.html
+++ b/tests/browser/fixtures/blank.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>GlueSQL browser test fixture</title>
+  </head>
+  <body></body>
+</html>

--- a/tests/browser/proxy.spec.js
+++ b/tests/browser/proxy.spec.js
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/tests/browser/fixtures/blank.html');
+  await page.evaluate(async () => {
+    const { gluesql } = await import('/gluesql.opfs.js');
+    window.gluesql = gluesql;
+  });
+});
+
+test('runs queries through the proxy/worker boundary', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const db = window.gluesql();
+
+    return db.query(`
+      CREATE TABLE Foo (id INTEGER, name TEXT);
+      INSERT INTO Foo VALUES (1, 'hello'), (2, 'worker');
+      SELECT * FROM Foo ORDER BY id;
+    `);
+  });
+
+  expect(result).toEqual([
+    { type: 'CREATE TABLE' },
+    { type: 'INSERT', affected: 2 },
+    {
+      type: 'SELECT',
+      rows: [
+        { id: 1, name: 'hello' },
+        { id: 2, name: 'worker' },
+      ],
+    },
+  ]);
+});
+
+test('propagates worker query errors and stays usable', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const db = window.gluesql();
+
+    const queryError = await db
+      .query('SELECT * FROM Missing')
+      .then(() => 'resolved')
+      .catch((error) => error.message);
+
+    const afterError = await db.query('SELECT 1 AS one');
+
+    return { queryError, afterError };
+  });
+
+  expect(result.queryError).toContain('table not found: Missing');
+  expect(result.afterError).toEqual([
+    { type: 'SELECT', rows: [{ one: 1 }] },
+  ]);
+});
+
+test('matches concurrent responses to their requests', async ({ page }) => {
+  const results = await page.evaluate(async () => {
+    const db = window.gluesql();
+
+    await db.query(`
+      CREATE TABLE Foo (id INTEGER, name TEXT);
+      INSERT INTO Foo VALUES
+        (0, 'row-0'), (1, 'row-1'), (2, 'row-2'), (3, 'row-3'), (4, 'row-4'),
+        (5, 'row-5'), (6, 'row-6'), (7, 'row-7'), (8, 'row-8'), (9, 'row-9');
+    `);
+
+    const ids = Array.from({ length: 10 }, (_, i) => i);
+
+    return Promise.all(
+      ids.map((id) =>
+        db
+          .query(`SELECT name FROM Foo WHERE id = ${id}`)
+          .then(([payload]) => payload.rows[0].name),
+      ),
+    );
+  });
+
+  expect(results).toEqual(
+    Array.from({ length: 10 }, (_, i) => `row-${i}`),
+  );
+});
+
+test('rejects in-flight and subsequent queries after terminate', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const db = window.gluesql();
+
+    const inFlight = db
+      .query('SELECT 1 AS one')
+      .then(() => 'resolved')
+      .catch((error) => error.message);
+
+    db.terminate();
+
+    const afterTerminate = await db
+      .query('SELECT 1 AS one')
+      .then(() => 'resolved')
+      .catch((error) => error.message);
+
+    return { inFlight: await inFlight, afterTerminate };
+  });
+
+  expect(result.inFlight).toBe('worker terminated');
+  expect(result.afterTerminate).toBe('worker terminated');
+});
+
+test('rejects queries when the worker fails to load', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const db = window.gluesql(new URL('/does-not-exist.worker.js', location.origin));
+
+    const initialFailure = await db
+      .query('SELECT 1 AS one')
+      .then(() => 'resolved')
+      .catch(() => 'rejected');
+
+    const afterFailure = await db
+      .query('SELECT 1 AS one')
+      .then(() => 'resolved')
+      .catch(() => 'rejected');
+
+    return { initialFailure, afterFailure };
+  });
+
+  expect(result.initialFailure).toBe('rejected');
+  expect(result.afterFailure).toBe('rejected');
+});


### PR DESCRIPTION
## Summary

Add automated browser coverage for the JavaScript proxy layer
(`gluesql.opfs.js` / `gluesql.opfs.worker.js`), following up on the #13
review. The wasm-bindgen tests cover the WASM binding inside a worker, but
the proxy layer itself had no automated coverage — which is exactly where
the lifecycle issue in #13 was found.

Landing this before the opfs-storage work gives regression protection for
the next PR, which will rework worker initialization (async OPFS handle
acquisition) and its failure paths. The suite only exercises the proxy
contract, so the current memory scaffolding is sufficient.

Closes #14

## Changes

- add a Playwright suite (`tests/browser/proxy.spec.js`) covering the four
  scenarios suggested in the #13 review:
  - successful queries through the proxy/worker boundary
  - worker query errors reaching the proxy, with later queries staying
    usable (recoverable, unlike terminal errors)
  - concurrent request ID matching (10 in-flight queries, each response
    matched to its own promise)
  - termination and worker-load failure behavior — the lifecycle-repro
    scenarios from #13 as assertions
- add `playwright.config.js` (Chromium, static file server, CI retries) and
  an `npm run test:browser` script
- add a `js_proxy_tests` CI job: build the OPFS package, install Chromium,
  run the suite
- ignore `playwright-report/` and `test-results/`

## Test

- `npm run test:browser` — 5 passed
- existing wasm-bindgen and Node test paths untouched