### PR TITLE
Package the OPFS entry point for npm releases

### DIFF
--- a/.github/workflows/publish-javascript.yml
+++ b/.github/workflows/publish-javascript.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Build package files
         run: |
           npm run build:web
+          npm run build:opfs
           npm run build:node -- --target x86_64-unknown-linux-gnu
           npx napi artifacts --output-dir artifacts --npm-dir npm
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,43 @@ await db.query(`
 
 Node.js currently supports only non-persistent memory storage.
 
+## OPFS Entry Point
+
+`gluesql/opfs` is a separate worker-based entry point backed by the
+[Origin Private File System](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system).
+GlueSQL runs inside a Dedicated Worker and stores data in a file under the
+OPFS root, so data survives page reloads and browser restarts.
+
+```javascript
+import { gluesql } from 'gluesql/opfs';
+
+const db = gluesql();
+
+await db.query(`
+  CREATE TABLE User (id INTEGER, name TEXT);
+  INSERT INTO User VALUES (1, 'glue');
+`);
+
+// After a reload, the data is still there:
+const [result] = await db.query('SELECT * FROM User');
+```
+
+Options:
+
+```javascript
+// Separate databases per namespace (each namespace is its own OPFS file)
+const app1 = gluesql({ namespace: 'app1' });
+const app2 = gluesql({ namespace: 'app2' });
+```
+
+Notes:
+
+- OPFS requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or localhost).
+- This entry point provides OPFS as its only storage; the `ENGINE` clause
+  and `setDefaultEngine` from the main browser entry point do not apply.
+- A namespace can be opened by one context at a time — the underlying
+  sync access handle is exclusive.
+
 ## License
 
 This project is licensed under the Apache License, Version 2.0 - see the [LICENSE](https://raw.githubusercontent.com/gluesql/gluesql-js/main/LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,16 @@
   "description": "GlueSQL is quite sticky, it attaches to anywhere",
   "browser": "gluesql.js",
   "main": "gluesql.node.js",
+  "exports": {
+    ".": {
+      "browser": "./gluesql.js",
+      "default": "./gluesql.node.js"
+    },
+    "./opfs": "./gluesql.opfs.js",
+    "./gluesql.js": "./gluesql.js",
+    "./gluesql.rollup.js": "./gluesql.rollup.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "npm run build:web && npm run build:node",
     "build:web": "wasm-pack build --no-pack --target web --no-typescript --release --out-dir ./dist_web",
@@ -39,8 +49,12 @@
     "gluesql.native.d.ts",
     "dist_web/gluesql_js.js",
     "dist_web/gluesql_js_bg.wasm",
+    "dist_opfs/gluesql_js.js",
+    "dist_opfs/gluesql_js_bg.wasm",
     "gluesql.js",
     "gluesql.node.js",
+    "gluesql.opfs.js",
+    "gluesql.opfs.worker.js",
     "gluesql.rollup.js",
     "package.json",
     "README.md"


### PR DESCRIPTION
Expose `gluesql/opfs` via an exports map, ship the entry files and dist_opfs build in the package, 
build them in the publish workflow, and document usage in the README.