### PR TITLE
Remove deprecated Cargo authors fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ wildcard_imports = "allow"
 
 [package]
 name = "gluesql-js"
-authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 version.workspace = true
 edition.workspace = true
 description.workspace = true

--- a/storages/opfs-storage/Cargo.toml
+++ b/storages/opfs-storage/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "gluesql-opfs-storage"
-authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 version.workspace = true
 edition.workspace = true
 description.workspace = true

--- a/storages/web-storage/Cargo.toml
+++ b/storages/web-storage/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "gluesql-web-storage"
-authors = ["Taehoon Moon <taehoon.moon@outlook.com>"]
 version.workspace = true
 edition.workspace = true
 description.workspace = true


### PR DESCRIPTION
## Summary

- Remove the deprecated `authors` field from all three Cargo package manifests
- Keep GlueSQL JS package metadata aligned with GlueSQL and current Cargo guidance

## Context

Cargo now explicitly documents the optional `authors` field as deprecated. It remains available in package metadata and through `CARGO_PKG_AUTHORS` only for backwards compatibility.

This mirrors [GlueSQL PR #2012](https://github.com/gluesql/gluesql/pull/2012) and applies the same metadata cleanup to the GlueSQL JS root, web storage, and OPFS storage packages.

- [Cargo manifest reference: the `authors` field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field)
- [Tracking issue for RFC 3052](https://github.com/rust-lang/rust/issues/83227)
- [RFC 3052](https://github.com/rust-lang/rfcs/pull/3052)