### PR TITLE
Add OPFS example with Playwright tests and workflow integration

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -131,7 +131,7 @@ jobs:
         run: wasm-pack test --headless --firefox . -p gluesql-js --features opfs --test opfs
 
   js_proxy_tests:
-    name: Worker proxy tests
+    name: Worker proxy and example tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -149,13 +149,16 @@ jobs:
         with:
           version: "v0.13.1"
 
+      - name: Build web package
+        run: npm run build:web
+
       - name: Build OPFS package
         run: npm run build:opfs
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run worker proxy tests
+      - name: Run worker proxy and example tests
         run: npm run test:browser
 
   js_storage_tests:

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ Notes:
 - A namespace can be opened by one context at a time — the underlying
   sync access handle is exclusive.
 
+A runnable demo with a persistent visit counter and an interactive SQL runner
+lives in [`examples/web/opfs`](examples/web/opfs/README.md).
+
 ## License
 
 This project is licensed under the Apache License, Version 2.0 - see the [LICENSE](https://raw.githubusercontent.com/gluesql/gluesql-js/main/LICENSE) file for details.

--- a/examples/web/opfs/README.md
+++ b/examples/web/opfs/README.md
@@ -1,0 +1,53 @@
+## Guide: Running opfs example
+
+This example demonstrates the `gluesql/opfs` entry point: GlueSQL runs inside
+a Dedicated Worker and stores data in a database file under the
+[Origin Private File System](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system),
+so data survives page reloads and browser restarts.
+
+### How to run?
+
+1. Build the OPFS package from the repository root:
+
+```sh
+npm run build:opfs
+```
+
+2. Serve the repository root with any static http server:
+
+```sh
+python3 -m http.server 8765
+```
+
+3. Open <http://localhost:8765/examples/web/opfs/index.html> in a
+   Chromium-based browser, Firefox, or Safari.
+
+> OPFS requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts),
+> so serve the page over `localhost` (as above) or HTTPS — opening the file
+> directly via `file://` does not work.
+
+### What to try
+
+- **Persistence** — the page header shows `This page has been loaded N time(s)`.
+  Every load inserts a row into the `Visit` table, so the counter grows on each
+  reload and even survives a full browser restart. The data lives in an
+  `example.db` file under the OPFS root.
+- **SQL runner** — type any SQL into the textarea and press *Run*. Results with
+  rows render as a table; other payloads print their type. For example:
+
+  ```sql
+  CREATE TABLE Todo (id INTEGER, task TEXT);
+  INSERT INTO Todo VALUES (1, 'first'), (2, 'second');
+  SELECT * FROM Todo;
+  ```
+
+  Reload the page — the `Todo` table is still there.
+- **Errors** — running something like `SELECT * FROM Missing;` shows the error
+  message inline in red.
+
+### Inspecting and resetting the stored data
+
+In Chromium DevTools, open *Application → Storage → Origin Private File System*
+to see the `example.db` file. To start fresh, use *Clear site data* in the same
+panel (or `navigator.storage.getDirectory()` from the console to remove entries
+manually).

--- a/examples/web/opfs/index.html
+++ b/examples/web/opfs/index.html
@@ -6,66 +6,133 @@
     <script type="module">
       import { gluesql } from '../../../gluesql.opfs.js';
 
+      const status = document.querySelector('#status');
+      const results = document.querySelector('#results');
+
       const showError = (message) => {
-        document.querySelector('#status').textContent = `FAILED: ${message}`;
+        status.textContent = `FAILED: ${message}`;
       };
       window.addEventListener('error', (e) => showError(e.message));
       window.addEventListener('unhandledrejection', (e) => showError(String(e.reason)));
 
-      async function run() {
-        const db = gluesql();
+      const renderPayloads = (payloads) => {
+        results.replaceChildren();
 
-        try {
-          const result = await db.query(`
-            DROP TABLE IF EXISTS Foo;
-            CREATE TABLE Foo (id INTEGER, name TEXT);
-            INSERT INTO Foo VALUES (1, 'hello'), (2, 'worker');
-            SELECT * FROM Foo;
-          `);
+        for (const payload of payloads) {
+          if (payload.rows) {
+            const columns = [...new Set(payload.rows.flatMap(Object.keys))];
+            const table = document.createElement('table');
+            const head = table.createTHead().insertRow();
 
-          for (const item of result) {
-            const node = document.createElement('code');
+            for (const column of columns) {
+              const th = document.createElement('th');
+              th.textContent = column;
+              head.append(th);
+            }
 
-            node.textContent = [
-              `type: ${item.type}`,
-              item.affected !== undefined ? `affected: ${item.affected}` : '',
-              item.rows ? `rows: ${JSON.stringify(item.rows)}` : '',
-            ].filter(Boolean).join(' | ');
+            const body = table.createTBody();
+            for (const row of payload.rows) {
+              const tr = body.insertRow();
+              for (const column of columns) {
+                tr.insertCell().textContent = JSON.stringify(row[column]);
+              }
+            }
 
-            document.querySelector('#box').append(node);
+            results.append(table);
+          } else {
+            const line = document.createElement('code');
+            line.textContent = [
+              payload.type,
+              payload.affected !== undefined ? `(affected: ${payload.affected})` : '',
+            ].filter(Boolean).join(' ');
+            results.append(line);
           }
-
-          document.querySelector('#status').textContent = 'OK: query ran inside the worker';
-        } catch (error) {
-          document.querySelector('#status').textContent = `FAILED: ${error.message}`;
         }
+      };
+
+      const db = gluesql({ namespace: 'example' });
+
+      async function main() {
+        await db.query(`
+          CREATE TABLE IF NOT EXISTS Visit (at TEXT);
+        `);
+        await db.query(`INSERT INTO Visit VALUES ('${new Date().toISOString()}');`);
+
+        const [{ rows }] = await db.query('SELECT COUNT(*) AS count FROM Visit;');
+        document.querySelector('#visit-count').textContent = rows[0].count;
+
+        document.querySelector('#run').addEventListener('click', async () => {
+          try {
+            renderPayloads(await db.query(document.querySelector('#sql').value));
+          } catch (error) {
+            results.replaceChildren();
+            const line = document.createElement('code');
+            line.textContent = `Error: ${error.message}`;
+            line.className = 'error';
+            results.append(line);
+          }
+        });
+
+        status.textContent = 'ready';
       }
 
-      run();
+      main().catch((error) => showError(error.message));
     </script>
     <style>
-      body { padding: 0; margin: 0; }
-      #box {
-        display: flex;
-        flex-direction: column;
-        padding: 20px;
+      body {
+        margin: 0;
+        padding: 24px;
         background-color: #222;
         color: white;
-        min-height: 100vh;
+        font-family: monospace;
+      }
+      h1 { font-size: 1.2rem; }
+      #status { color: #8f8; }
+      #visits { margin: 16px 0; }
+      #visit-count { font-weight: bold; }
+      textarea {
+        width: 100%;
+        max-width: 640px;
+        height: 96px;
+        background: #111;
+        color: white;
+        font-family: monospace;
+        border: 1px solid #555;
+        padding: 8px;
         box-sizing: border-box;
       }
-      code {
-        margin: 5px;
-        padding: 10px;
+      button {
+        display: block;
+        margin: 8px 0 16px;
+        padding: 6px 16px;
+        background: #333;
+        color: white;
+        border: 1px solid #777;
         font-family: monospace;
-        border: 1px solid white;
+        cursor: pointer;
       }
-      #status { font-family: monospace; padding: 10px 5px; }
+      button:hover { background: #444; }
+      table { border-collapse: collapse; margin: 8px 0; }
+      th, td { border: 1px solid #555; padding: 4px 10px; text-align: left; }
+      th { background: #333; }
+      code { display: block; padding: 4px 0; }
+      .error { color: #f88; }
     </style>
   </head>
   <body>
-    <div id="box">
-      <div id="status">loading...</div>
-    </div>
+    <h1>GlueSQL OPFS example</h1>
+    <div id="status">loading...</div>
+
+    <p id="visits">
+      This page has been loaded <span id="visit-count">-</span> time(s).
+      The counter lives in a database file under OPFS — reload the page,
+      restart the browser, it survives.
+    </p>
+
+    <textarea id="sql" spellcheck="false">
+SELECT * FROM Visit ORDER BY at DESC;</textarea>
+    <button id="run">Run</button>
+
+    <div id="results"></div>
   </body>
 </html>

--- a/tests/browser/examples.spec.js
+++ b/tests/browser/examples.spec.js
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test('module example runs its queries', async ({ page }) => {
+  await page.goto('/examples/web/module/index.html');
+
+  await expect(page.locator('#box code')).toHaveCount(7);
+  await expect(page.locator('#box')).toContainText('wow_id');
+  await expect(page.locator('#box')).toContainText('schemaless');
+});
+
+test('opfs example counts visits across reloads and runs queries', async ({ page }) => {
+  await page.goto('/examples/web/opfs/index.html');
+  await expect(page.locator('#status')).toHaveText('ready');
+  await expect(page.locator('#visit-count')).toHaveText('1');
+
+  await page.locator('#sql').fill('SELECT 1 AS one;');
+  await page.locator('#run').click();
+  await expect(page.locator('#results td')).toHaveText('1');
+
+  await page.locator('#sql').fill('SELECT * FROM Missing;');
+  await page.locator('#run').click();
+  await expect(page.locator('#results .error')).toContainText('table not found: Missing');
+
+  await page.reload();
+  await expect(page.locator('#status')).toHaveText('ready');
+  await expect(page.locator('#visit-count')).toHaveText('2');
+
+  await page.locator('#run').click();
+  await expect(page.locator('#results td')).toHaveCount(2);
+});


### PR DESCRIPTION
## Summary

- Rework `examples/web/opfs/index.html` from a one-shot fixed query into an
  interactive demo: a visit counter persisted in OPFS (survives reloads and
  browser restarts) and a SQL runner that renders rows as tables and errors
  inline.
- Add Playwright tests for the web examples (`tests/browser/examples.spec.js`),
  covering the module example and the OPFS example's persistence across reloads.
- Run the example tests in CI: build the web package in the proxy-test job and
  rename it to "Worker proxy and example tests".
- Document how to run the OPFS example (`examples/web/opfs/README.md`) and link
  it from the root README.

## Test plan

- [x] `npm run test:browser` — module + OPFS example specs pass
- [x] Verified manually in Chromium: visit counter increments across reloads,
      SQL runner renders results and errors