### PR TITLE
Switch gluesql dependencies to crates.io v0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,8 +484,9 @@ dependencies = [
 
 [[package]]
 name = "gluesql-composite-storage"
-version = "0.19.0"
-source = "git+https://github.com/gluesql/gluesql.git?rev=aae2a135146be08fb99f7b97782a58ca1cb10412#aae2a135146be08fb99f7b97782a58ca1cb10412"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05231f43c6ee489e8a1e73eb2c62379c3b623c21d20fb8143c0c6630e8ab6e1f"
 dependencies = [
  "gluesql-core",
  "serde",
@@ -493,8 +494,9 @@ dependencies = [
 
 [[package]]
 name = "gluesql-core"
-version = "0.19.0"
-source = "git+https://github.com/gluesql/gluesql.git?rev=aae2a135146be08fb99f7b97782a58ca1cb10412#aae2a135146be08fb99f7b97782a58ca1cb10412"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7156a8881f2d54bfbc0c49b8091c179d59e88c940075b4cf8011c70fdda5087d"
 dependencies = [
  "bigdecimal",
  "cfg-if",
@@ -556,8 +558,9 @@ dependencies = [
 
 [[package]]
 name = "gluesql-redb-storage"
-version = "0.19.0"
-source = "git+https://github.com/gluesql/gluesql.git?rev=aae2a135146be08fb99f7b97782a58ca1cb10412#aae2a135146be08fb99f7b97782a58ca1cb10412"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b4d9c478f3c414eeeb0f6b082f63f32deed76b54f191fac6544cdbc459d05c"
 dependencies = [
  "bincode",
  "gluesql-core",
@@ -569,8 +572,9 @@ dependencies = [
 
 [[package]]
 name = "gluesql-test-suite"
-version = "0.19.0"
-source = "git+https://github.com/gluesql/gluesql.git?rev=aae2a135146be08fb99f7b97782a58ca1cb10412#aae2a135146be08fb99f7b97782a58ca1cb10412"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e151cf71282b4226950ab214e7ec1830c6287c84d32e08b61b4a28cf97dde"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -601,8 +605,9 @@ dependencies = [
 
 [[package]]
 name = "gluesql_memory_storage"
-version = "0.19.0"
-source = "git+https://github.com/gluesql/gluesql.git?rev=aae2a135146be08fb99f7b97782a58ca1cb10412#aae2a135146be08fb99f7b97782a58ca1cb10412"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6882603ba8d6292e8b64cd42ad2b246cd144ecf880de4bc48173c59c3b22813b"
 dependencies = [
  "gluesql-core",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "gluesql-js"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "gluesql-opfs-storage"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "getrandom 0.2.17",
  "gluesql-core",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "gluesql-web-storage"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "getrandom 0.2.17",
  "gloo-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 description = "GlueSQL - Open source SQL database engine fully written in Rust with pure functional execution layer, easily swappable storage and web assembly support!"
 license = "Apache-2.0"
@@ -24,8 +24,8 @@ gluesql-core = "0.20.0"
 gluesql_memory_storage = "0.20.0"
 gluesql-composite-storage = "0.20.0"
 gluesql-redb-storage = "0.20.0"
-gluesql-opfs-storage = { path = "storages/opfs-storage", version = "0.19.0" }
-gluesql-web-storage = { path = "storages/web-storage", version = "0.19.0" }
+gluesql-opfs-storage = { path = "storages/opfs-storage", version = "0.20.0" }
+gluesql-web-storage = { path = "storages/web-storage", version = "0.20.0" }
 test-suite = { package = "gluesql-test-suite", version = "0.20.0" }
 getrandom = { version = "0.2", features = ["js"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ repository = "https://github.com/gluesql/gluesql-js"
 documentation = "https://docs.rs/gluesql/"
 
 [workspace.dependencies]
-gluesql-core = { git = "https://github.com/gluesql/gluesql.git", rev = "aae2a135146be08fb99f7b97782a58ca1cb10412" }
-gluesql_memory_storage = { git = "https://github.com/gluesql/gluesql.git", rev = "aae2a135146be08fb99f7b97782a58ca1cb10412" }
-gluesql-composite-storage = { git = "https://github.com/gluesql/gluesql.git", rev = "aae2a135146be08fb99f7b97782a58ca1cb10412" }
-gluesql-redb-storage = { git = "https://github.com/gluesql/gluesql.git", rev = "aae2a135146be08fb99f7b97782a58ca1cb10412" }
+gluesql-core = "0.20.0"
+gluesql_memory_storage = "0.20.0"
+gluesql-composite-storage = "0.20.0"
+gluesql-redb-storage = "0.20.0"
 gluesql-opfs-storage = { path = "storages/opfs-storage", version = "0.19.0" }
 gluesql-web-storage = { path = "storages/web-storage", version = "0.19.0" }
-test-suite = { package = "gluesql-test-suite", git = "https://github.com/gluesql/gluesql.git", rev = "aae2a135146be08fb99f7b97782a58ca1cb10412" }
+test-suite = { package = "gluesql-test-suite", version = "0.20.0" }
 getrandom = { version = "0.2", features = ["js"] }
 
 [workspace.lints.clippy]

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gluesql/native-darwin-arm64",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "cpu": [
     "arm64"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gluesql/native-darwin-x64",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "cpu": [
     "x64"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gluesql/native-linux-x64-gnu",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "cpu": [
     "x64"
   ],

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gluesql/native-win32-x64-msvc",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "cpu": [
     "x64"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluesql",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "GlueSQL is quite sticky, it attaches to anywhere",
   "browser": "gluesql.js",
   "main": "gluesql.node.js",
@@ -70,10 +70,10 @@
     ]
   },
   "optionalDependencies": {
-    "@gluesql/native-darwin-arm64": "0.19.0",
-    "@gluesql/native-darwin-x64": "0.19.0",
-    "@gluesql/native-linux-x64-gnu": "0.19.0",
-    "@gluesql/native-win32-x64-msvc": "0.19.0"
+    "@gluesql/native-darwin-arm64": "0.20.0",
+    "@gluesql/native-darwin-x64": "0.20.0",
+    "@gluesql/native-linux-x64-gnu": "0.20.0",
+    "@gluesql/native-win32-x64-msvc": "0.20.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.7.1",


### PR DESCRIPTION
## Summary

GlueSQL v0.20.0 is now published on crates.io, so the temporary git rev pins
are no longer needed.

- Replace the five git rev dependencies (`gluesql-core`,
  `gluesql_memory_storage`, `gluesql-composite-storage`,
  `gluesql-redb-storage`, `gluesql-test-suite`) with `"0.20.0"` from crates.io.
- The pinned rev (`aae2a13`) was an ancestor of the `v0.20.0` tag, 18 commits
  behind. This picks those up, including the CompositeStorage rollback
  delegation fix (gluesql/gluesql#1963), which this package uses.
- Bump every package version to 0.20.0: the Cargo workspace, the npm
  `package.json`, the `@gluesql/native-*` optionalDependencies pins, and the
  napi sub-packages under `npm/`.
- No code changes required — the sync core migration was already included in
  the pinned rev, and the remaining commits are API-compatible.
- No storage migration needed: `storages/redb-storage` sources are unchanged
  between the pinned rev and the release, so `REDB_STORAGE_FORMAT_VERSION`
  and the redb file format are identical.

## Why the version bump is part of this PR

`SHOW VERSION` reports gluesql-core's version, and `tests/payload.rs` asserts
it equals this package's `CARGO_PKG_VERSION`. The first CI run failed exactly
on that assertion (`0.20.0` vs `0.19.0`), which shows the core upgrade and the
package version bump have to land together. Aligning the npm-side versions in
the same commit keeps everything ready for the next npm publish.

## Test plan

- [x] `cargo check --workspace` (native + `wasm32-unknown-unknown --features opfs`)
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets` — no warnings
- [x] `wasm-pack test --headless --chrome -p gluesql-js` — full browser suite
      including the `payload` SHOW VERSION assertion that failed on CI
- [x] `wasm-pack test --headless --chrome --features opfs --test opfs` — 6 passed,
      including `persists_across_reopen`
- [x] `npm run build:web` / `build:opfs` / `build:node`
- [x] `npm run test:node`
- [x] `npm run test:browser`