### PR TITLE
Add multi-tab OPFS support with leader election and failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,54 @@ Notes:
 A runnable demo with a persistent visit counter and an interactive SQL runner
 lives in [`examples/web/opfs`](examples/web/opfs/README.md).
 
+### Multi-tab access: `gluesql/opfs/shared` (experimental)
+
+`gluesql/opfs/shared` lets multiple tabs of the same origin query one OPFS
+namespace. Tabs compete for a [Web Lock](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API)
+per namespace; the holder is the leader — only it spawns the database worker
+and holds the exclusive sync access handle — and tabs exchange queries and
+results over a `BroadcastChannel`. (A tab must lead because sync access
+handles exist only in Dedicated Workers.)
+
+```javascript
+import { gluesql } from 'gluesql/opfs/shared';
+
+const db = gluesql({ namespace: 'app' });
+
+await db.query(`CREATE TABLE IF NOT EXISTS Log (at TEXT);`);
+```
+
+Failover: when the leader tab closes, crashes, or is frozen, the browser
+releases its lock — no heartbeat needed — and the next tab in line takes over
+the OPFS handle with retry/backoff, then announces itself. Queries that never
+reached the lost leader are resent automatically; queries the lost leader had
+already accepted are rejected with a `leader lost` error instead of being
+replayed — no one can know whether they were applied, so replaying could
+double-apply writes.
+
+Known side effects and caveats:
+
+- **In-flight ambiguity on failover** — a query rejected with `leader lost`
+  may or may not have been applied. Retry idempotent reads freely; guard
+  non-idempotent writes at the application level. In the instant of a hard
+  crash an acceptance message can theoretically be lost, letting a resend
+  replay a query the leader had just started — the same guard applies.
+- **Failover latency** — the lock is released as soon as the leader dies, but
+  the new leader may need retry/backoff while the old OPFS handle is
+  released.
+- **Back/forward cache** — leaving a page terminates its connection so the
+  handle can move on; a page restored from bfcache must create a new
+  `gluesql()` instance.
+- **No Web Locks or BroadcastChannel, no multi-tab** — where either API is
+  unavailable, this entry point silently falls back to single-context
+  `gluesql/opfs` behavior, including its one-tab limit.
+- **Leader tab does the work** — queries from every tab execute in whichever
+  tab currently leads; heavy queries consume that tab's CPU. Results are
+  broadcast, so every tab on the namespace pays a copy of each result.
+- **One protocol per origin** — the lock and channel are keyed only by
+  namespace, so mixed app versions on one origin share them; keep the
+  message protocol stable.
+
 ## License
 
 This project is licensed under the Apache License, Version 2.0 - see the [LICENSE](https://raw.githubusercontent.com/gluesql/gluesql-js/main/LICENSE) file for details.

--- a/gluesql.opfs.shared.js
+++ b/gluesql.opfs.shared.js
@@ -1,0 +1,316 @@
+// Multi-tab OPFS entry point: tabs sharing a namespace elect a leader with
+// the Web Locks API — the lock holder spawns `gluesql.opfs.worker.js` and
+// owns the exclusive sync access handle — and exchange queries over a
+// BroadcastChannel. The browser releases the lock when the leader dies, so
+// failover needs no heartbeat.
+
+import { gluesql as singleContext } from './gluesql.opfs.js';
+
+const LEAD_ATTEMPTS = 8;
+const LEAD_RETRY_BASE_MS = 100;
+const RELEAD_DELAY_MS = 1000;
+
+const AMBIGUOUS =
+  'opfs-shared: leader lost; the query may or may not have been applied';
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Probe with backoff: right after failover the old handle may not be
+// released yet.
+const acquireWorker = async (workerUrl) => {
+  let lastError = 'unknown';
+
+  for (let attempt = 0; attempt < LEAD_ATTEMPTS; attempt += 1) {
+    if (attempt > 0) {
+      await delay(LEAD_RETRY_BASE_MS * 2 ** (attempt - 1));
+    }
+
+    const worker = new Worker(workerUrl, { type: 'module' });
+
+    const probe = await new Promise((resolve) => {
+      worker.onmessage = ({ data }) => resolve(data.error);
+      worker.onerror = (event) =>
+        resolve(event.message ?? 'worker failed to load');
+      worker.postMessage({ id: 'probe', sql: 'SELECT 1' });
+    });
+
+    if (probe === undefined) {
+      worker.onmessage = null;
+      worker.onerror = null;
+
+      return worker;
+    }
+
+    worker.terminate();
+    lastError = probe;
+  }
+
+  throw new Error(lastError);
+};
+
+export function gluesql({ namespace, workerUrl } = {}) {
+  const dbWorkerUrl = new URL(
+    workerUrl ?? './gluesql.opfs.worker.js',
+    import.meta.url,
+  );
+
+  if (namespace !== undefined) {
+    dbWorkerUrl.searchParams.set('namespace', namespace);
+  }
+
+  if (
+    typeof BroadcastChannel === 'undefined' ||
+    typeof navigator === 'undefined' ||
+    navigator.locks === undefined
+  ) {
+    return singleContext({ namespace, workerUrl });
+  }
+
+  // Lock and channel are origin-scoped, same as OPFS — one per namespace.
+  const scope = `gluesql-opfs:${namespace ?? ''}`;
+  const channel = new BroadcastChannel(scope);
+  const tabId = crypto.randomUUID();
+
+  const pending = new Map(); // id -> { resolve, reject, sql, acceptedBy }
+  let nextSeq = 0;
+  let terminalError = null;
+  let closed = false;
+
+  // ---- leader state, set only while this instance holds the lock ----
+  let dbWorker = null;
+  let epoch = null;
+  let releaseLock = null;
+  const handled = new Set(); // clients may resend after `leader-ready`
+
+  const fail = (error) => {
+    if (terminalError !== null) {
+      return;
+    }
+
+    terminalError = error;
+
+    for (const { reject } of pending.values()) {
+      reject(error);
+    }
+
+    pending.clear();
+  };
+
+  // BroadcastChannel never delivers to its own sender, so leader-bound and
+  // client-bound messages each take a local shortcut within this tab.
+  const submit = (message) => {
+    if (closed) {
+      return;
+    }
+
+    if (epoch !== null) {
+      onLeaderMessage(message);
+    } else {
+      channel.postMessage(message);
+    }
+  };
+
+  const publish = (message) => {
+    if (closed) {
+      return;
+    }
+
+    channel.postMessage(message);
+    onClientMessage(message);
+  };
+
+  const onClientMessage = (data) => {
+    switch (data.type) {
+      case 'accepted': {
+        const request = pending.get(data.id);
+
+        if (request !== undefined) {
+          request.acceptedBy = data.epoch;
+        }
+        break;
+      }
+      case 'answer': {
+        const request = pending.get(data.id);
+
+        if (request !== undefined) {
+          pending.delete(data.id);
+
+          if (data.error === undefined) {
+            request.resolve(data.result);
+          } else {
+            request.reject(new Error(data.error));
+          }
+        }
+        break;
+      }
+      case 'leader-ready': {
+        for (const [id, request] of pending) {
+          if (request.acceptedBy === null) {
+            // never reached a leader — safe to resend, the leader dedupes
+            submit({ type: 'query', id, sql: request.sql });
+          } else if (request.acceptedBy !== data.epoch) {
+            // Replaying could double-apply: the lost leader may have run it.
+            pending.delete(id);
+            request.reject(new Error(AMBIGUOUS));
+          }
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  const onLeaderMessage = (data) => {
+    switch (data.type) {
+      case 'query': {
+        if (!handled.has(data.id)) {
+          handled.add(data.id);
+          publish({ type: 'accepted', id: data.id, epoch });
+          dbWorker.postMessage({ id: data.id, sql: data.sql });
+        }
+        break;
+      }
+      case 'who-leads': {
+        publish({ type: 'leader-ready', epoch });
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  channel.onmessage = ({ data }) => {
+    switch (data.type) {
+      case 'query':
+      case 'who-leads': {
+        if (epoch !== null) {
+          onLeaderMessage(data);
+        }
+        break;
+      }
+      default:
+        onClientMessage(data);
+    }
+  };
+
+  const stopLeading = () => {
+    epoch = null;
+    handled.clear();
+
+    if (dbWorker !== null) {
+      dbWorker.terminate();
+      dbWorker = null;
+    }
+
+    if (releaseLock !== null) {
+      releaseLock();
+      releaseLock = null;
+    }
+  };
+
+  const lead = async () => {
+    let worker;
+
+    try {
+      worker = await acquireWorker(dbWorkerUrl);
+    } catch (error) {
+      // We held the exclusive lock, so any previous leader is gone; settle
+      // our own pending instead of letting it hang.
+      for (const [id, request] of pending) {
+        pending.delete(id);
+        request.reject(
+          new Error(
+            request.acceptedBy === null
+              ? `opfs-shared: failed to lead: ${error.message ?? error}`
+              : AMBIGUOUS,
+          ),
+        );
+      }
+
+      return;
+    }
+
+    if (closed) {
+      worker.terminate();
+
+      return;
+    }
+
+    dbWorker = worker;
+    epoch = crypto.randomUUID();
+    dbWorker.onmessage = ({ data }) =>
+      publish({
+        type: 'answer',
+        id: data.id,
+        error: data.error,
+        result: data.result,
+      });
+    dbWorker.onerror = () => stopLeading(); // abdicate; the loop re-elects
+
+    publish({ type: 'leader-ready', epoch });
+
+    await new Promise((release) => {
+      releaseLock = release;
+    });
+  };
+
+  const leadLoop = async () => {
+    while (!closed) {
+      try {
+        await navigator.locks.request(scope, async () => {
+          if (!closed) {
+            await lead();
+          }
+        });
+      } catch {
+        return; // lock manager unavailable (e.g. document tearing down)
+      }
+
+      if (!closed) {
+        // Requests are granted in order, so waiting tabs go first; the
+        // delay only keeps a lone tab with a failing lead from spinning.
+        await delay(RELEAD_DELAY_MS);
+      }
+    }
+  };
+
+  const shutdown = (reason) => {
+    if (closed) {
+      return;
+    }
+
+    closed = true;
+    stopLeading();
+    channel.close();
+    fail(new Error(reason));
+  };
+
+  // fires on close, navigation, and bfcache entry — stop leading in all cases
+  addEventListener('pagehide', () => shutdown('page hidden'));
+  // Chrome can freeze hidden tabs; a frozen leader would strand the OPFS
+  // handle, so abdicate first and catch up on missed announcements at resume.
+  addEventListener('freeze', () => stopLeading());
+  addEventListener('resume', () => submit({ type: 'who-leads' }));
+
+  leadLoop();
+
+  return {
+    query(sql) {
+      if (terminalError !== null) {
+        return Promise.reject(terminalError);
+      }
+
+      return new Promise((resolve, reject) => {
+        const id = `${tabId}:${nextSeq}`;
+        nextSeq += 1;
+
+        pending.set(id, { resolve, reject, sql, acceptedBy: null });
+        submit({ type: 'query', id, sql });
+      });
+    },
+    terminate() {
+      shutdown('connection terminated');
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "./opfs": "./gluesql.opfs.js",
     "./gluesql.js": "./gluesql.js",
     "./gluesql.rollup.js": "./gluesql.rollup.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./opfs/shared": "./gluesql.opfs.shared.js"
   },
   "scripts": {
     "build": "npm run build:web && npm run build:node",
@@ -55,6 +56,7 @@
     "gluesql.node.js",
     "gluesql.opfs.js",
     "gluesql.opfs.worker.js",
+    "gluesql.opfs.shared.js",
     "gluesql.rollup.js",
     "package.json",
     "README.md"

--- a/tests/browser/shared.spec.js
+++ b/tests/browser/shared.spec.js
@@ -1,0 +1,159 @@
+import { test, expect } from '@playwright/test';
+
+const connect = async (page, namespace) => {
+  await page.goto('/tests/browser/fixtures/blank.html');
+  await page.evaluate(async (ns) => {
+    const { gluesql } = await import('/gluesql.opfs.shared.js');
+    window.db = gluesql({ namespace: ns });
+  }, namespace);
+};
+
+const query = (page, sql) => page.evaluate((q) => window.db.query(q), sql);
+
+// `leader lost` right after failover is documented policy — retry it here.
+const queryWithFailoverRetry = (page, sql) =>
+  page.evaluate(
+    ([q, retries]) => {
+      const run = (left) =>
+        window.db.query(q).catch((error) => {
+          if (left > 0 && error.message.includes('leader lost')) {
+            return new Promise((resolve) => setTimeout(resolve, 500)).then(
+              () => run(left - 1),
+            );
+          }
+
+          throw error;
+        });
+
+      return run(retries);
+    },
+    [sql, 3],
+  );
+
+test('two tabs query the same namespace through one leader', async ({
+  page,
+  context,
+}) => {
+  await connect(page, 'shared-two-tabs');
+  await query(
+    page,
+    `CREATE TABLE Item (id INTEGER, name TEXT);
+     INSERT INTO Item VALUES (1, 'from-tab-a');`,
+  );
+
+  const pageB = await context.newPage();
+  await connect(pageB, 'shared-two-tabs');
+
+  const [seenByB] = await query(
+    pageB,
+    "SELECT * FROM Item ORDER BY id;",
+  );
+  expect(seenByB.rows).toEqual([{ id: 1, name: 'from-tab-a' }]);
+
+  await query(pageB, "INSERT INTO Item VALUES (2, 'from-tab-b');");
+  const [seenByA] = await query(page, 'SELECT * FROM Item ORDER BY id;');
+  expect(seenByA.rows).toEqual([
+    { id: 1, name: 'from-tab-a' },
+    { id: 2, name: 'from-tab-b' },
+  ]);
+
+  const failure = await pageB.evaluate(() =>
+    window.db.query('SELECT * FROM Missing').catch((error) => error.message),
+  );
+  expect(failure).toContain('table not found: Missing');
+  const [alive] = await query(pageB, 'SELECT 1 AS one;');
+  expect(alive.rows).toEqual([{ one: 1 }]);
+});
+
+test('routes concurrent answers back to each of three tabs', async ({
+  page,
+  context,
+}) => {
+  await connect(page, 'shared-three-tabs');
+  await query(page, 'CREATE TABLE Seq (n INTEGER);');
+
+  const pageB = await context.newPage();
+  await connect(pageB, 'shared-three-tabs');
+  const pageC = await context.newPage();
+  await connect(pageC, 'shared-three-tabs');
+
+  const [b, c] = await Promise.all([
+    query(pageB, 'SELECT 2 AS me;'),
+    query(pageC, 'SELECT 3 AS me;'),
+  ]);
+  expect(b[0].rows).toEqual([{ me: 2 }]);
+  expect(c[0].rows).toEqual([{ me: 3 }]);
+
+  await query(pageB, 'INSERT INTO Seq VALUES (1);');
+  await query(pageC, 'INSERT INTO Seq VALUES (2);');
+  const [total] = await query(page, 'SELECT COUNT(*) AS count FROM Seq;');
+  expect(total.rows).toEqual([{ count: 2 }]);
+});
+
+test('closing the leader tab fails over to another tab', async ({
+  page,
+  context,
+}) => {
+  await connect(page, 'shared-failover');
+  await query(
+    page,
+    `CREATE TABLE Note (id INTEGER);
+     INSERT INTO Note VALUES (1);`,
+  );
+
+  const pageB = await context.newPage();
+  await connect(pageB, 'shared-failover');
+  const [before] = await queryWithFailoverRetry(
+    pageB,
+    'SELECT COUNT(*) AS count FROM Note;',
+  );
+  expect(before.rows).toEqual([{ count: 1 }]);
+
+  await page.close();
+
+  // Wait for the new leader with an idempotent read; retrying a write
+  // after `leader lost` could double-apply.
+  const [after] = await queryWithFailoverRetry(
+    pageB,
+    'SELECT COUNT(*) AS count FROM Note;',
+  );
+  expect(after.rows).toEqual([{ count: 1 }]);
+
+  await query(pageB, 'INSERT INTO Note VALUES (2);');
+  const [count] = await query(pageB, 'SELECT COUNT(*) AS count FROM Note;');
+  expect(count.rows).toEqual([{ count: 2 }]);
+});
+
+test('a query sent while no tab leads waits for the next leader', async ({
+  page,
+  context,
+}) => {
+  await connect(page, 'shared-releader');
+  await query(
+    page,
+    `CREATE TABLE Pending (id INTEGER);
+     INSERT INTO Pending VALUES (1);`,
+  );
+
+  const pageB = await context.newPage();
+  await connect(pageB, 'shared-releader');
+
+  // The leader is gone and pageB has not led yet; the query must be resent
+  // automatically once pageB acquires the lock — no retry helper.
+  await page.close();
+  const [rows] = await query(pageB, 'SELECT COUNT(*) AS count FROM Pending;');
+  expect(rows.rows).toEqual([{ count: 1 }]);
+});
+
+test('falls back to single-context mode without BroadcastChannel', async ({
+  context,
+}) => {
+  const page = await context.newPage();
+  await page.addInitScript(() => {
+    delete window.BroadcastChannel;
+  });
+
+  await connect(page, 'shared-fallback');
+  const [result] = await query(page, 'SELECT 1 AS one;');
+  expect(result.rows).toEqual([{ one: 1 }]);
+});


### PR DESCRIPTION
## Summary

Adds `gluesql/opfs/shared` (`gluesql.opfs.shared.js`), a new entry point that
lets multiple same-origin tabs query one OPFS namespace. The single-context
`gluesql/opfs` entry point is unchanged.

An OPFS sync access handle is exclusive and Dedicated-Worker-only, so only one
context can own the database at a time. This entry point elects one tab as the
leader and routes every other tab's queries to it:

- **Leader election — Web Locks.** Every tab requests a per-namespace lock
  (`gluesql-opfs:<ns>`); the holder is the leader and spawns
  `gluesql.opfs.worker.js`, which owns the handle and executes all SQL
  serially. Lock requests are FIFO, so succession order comes for free.
- **Query transport — BroadcastChannel.** Tabs broadcast `query` messages;
  the leader replies with `accepted` then `answer`. The leader's own queries
  short-circuit locally.

## Failover semantics

When the leader tab closes, crashes, or is frozen, the browser releases its
lock — there is no heartbeat or liveness code. The next tab takes over the
handle with retry/backoff and announces a new epoch (`leader-ready`):

- Queries **no leader had accepted** are resent automatically (the leader
  dedupes by id), so queries issued during an interregnum just wait.
- Queries **accepted by the lost leader** are rejected with a `leader lost`
  error instead of replayed — whether they were applied is unknowable, and
  replaying could double-apply writes. Documented in the README.

Lifecycle: `pagehide` tears the connection down; `freeze` abdicates leadership
first so a frozen tab never strands the OPFS handle; `resume` catches up on
missed announcements; a crashed DB worker abdicates and re-elects.

## Why not a SharedWorker coordinator

A SharedWorker cannot own the database (sync access handles are
Dedicated-Worker-only, and it cannot spawn one), so it could only route —
while requiring its own liveness machinery (heartbeats, timeouts, drop/re-elect
states) and being unavailable on Android WebView / Samsung Internet (Chrome
for Android only shipped it in 148). Web Locks turn death detection into a
browser responsibility and work everywhere OPFS does. Where Web Locks or
BroadcastChannel are missing, the entry point falls back to single-context
`gluesql/opfs` behavior.

## Testing

- `npx playwright test` — 12 passed: 5 new multi-tab specs (two-tab sharing,
  three-tab concurrent routing, leader-close failover, auto-resend while
  leaderless, single-context fallback) plus the existing 7 proxy specs.
- `node tests/nodejs.js` — passed (Node path untouched).