### PR TITLE
Strip symbols from native release builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+# The published .node ships one artifact per platform and nothing reads its
+# symbol table back, so drop it. This cannot live in `[profile.release]`:
+# stripping a wasm module also removes the `target_features` section, and
+# `wasm-opt` then rejects the bulk memory operations rustc emits.
+[target.'cfg(not(target_arch = "wasm32"))']
+rustflags = ["-C", "strip=symbols"]


### PR DESCRIPTION
The published package bundles one `.node` per platform (since #25), and nothing ever reads their symbol tables back — Node surfaces errors through the binding's `Error` values, not through native symbol names. Stripping is pure win for download size, and it now applies four times over per install.

| linux-x64, `CARGO_PROFILE_RELEASE_OPT_LEVEL=s` | raw | gzip |
| --- | --- | --- |
| today | 9.81 MB | 3.10 MB |
| with this change | 7.16 MB | 2.62 MB |

−27% raw and −15% over the wire, for six lines of config. Measured on linux-x64; the other three targets are built from the same crate and should land in the same range, so the tarball saving is roughly 10 MB raw.

## Why `.cargo/config.toml` and not `[profile.release]`

`strip` in `[profile.release]` also applies to the wasm builds, and stripping a wasm module removes its `target_features` custom section. `wasm-opt` reads that section to learn which proposals are enabled, so without it the bulk memory operations rustc emits fail validation and `npm run build:web` dies:

```
[wasm-validator error in function 9331] unexpected false: Bulk memory operations require bulk memory [--enable-bulk-memory], on
 (memory.copy ...)
Fatal: error validating input
Error: failed to execute `wasm-opt`
```

A `[target.'cfg(not(target_arch = "wasm32"))']` rustflags entry applies the flag to every native target — including the cross-compiled release targets — and leaves the wasm builds untouched.

`napi build --strip` is not an alternative: it is a macOS-only post-processing step. On linux the produced binary is byte-identical with and without the flag, and the rustc invocation it prints carries no `-C strip`.

## Note for future size work

`panic = "abort"` looks like the next obvious size knob and must not be added: the Redis storage path (in the storage-engine series) relies on `catch_unwind` to turn `RedisStorage::new`'s panic into a JavaScript error, and `abort` would take the process down instead.

## Verification

- `npm run build:node` → sizes above, `npm run test:node` passes
- `npm run build:web` → succeeds (this is the check that `[profile.release]` fails)
- `npm run build:opfs` → succeeds
