### PR TITLE
Add a storage engine registry to the Node.js binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,8 @@ dependencies = [
  "napi-sys",
  "nohash-hasher",
  "rustc-hash",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,14 +61,19 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["console_error_panic_hook"]
 
+# Node.js binding. The storage engines it registers are opt-in cargo features,
+# so a build only carries the backends it was asked for.
 nodejs = []
+# Every backend this crate can build.
+full = ["nodejs"]
+
 opfs = ["dep:gluesql-opfs-storage"]
 
 [dependencies]
 gluesql-core.workspace = true
 gluesql_memory_storage.workspace = true
 
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -87,7 +92,7 @@ gloo-utils = { version = "0.1.6", features = ["serde"] }
 console_error_panic_hook = { version = "0.1.6", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-napi = { version = "3", default-features = false, features = ["napi4"] }
+napi = { version = "3", default-features = false, features = ["napi4", "serde-json"] }
 napi-derive = "3"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -257,8 +257,52 @@ Remaining caveats, so you are not surprised in production:
 ## The same SQL in Node.js
 
 The `gluesql` package exposes the same API in Node.js, so schema and queries
-written for the browser run unchanged in tests and scripts. Node.js currently
-supports only non-persistent memory storage.
+written for the browser run unchanged in tests and scripts. In Node.js you also
+register the engines yourself: each name you register is a storage backend, and
+it is what the `ENGINE` clause of `CREATE TABLE` refers to.
+
+| Your data is… | Keep it in | `storage` |
+| --- | --- | --- |
+| Scratch state & caches | Memory | `memory` (default) |
+
+```javascript
+const { gluesql } = require('gluesql');
+
+// `memory` is always registered and starts out as the default engine.
+const db = gluesql();
+
+// Register engines up front...
+const scratch = gluesql({
+  engines: { scratch: { storage: 'memory' } },
+  defaultEngine: 'scratch',
+});
+
+// ...or at any time later.
+db.addEngine('scratch', { storage: 'memory' });
+
+db.listEngines(); // ['memory', 'scratch']
+db.defaultEngine(); // 'memory'
+db.removeEngine('scratch');
+```
+
+Tables of different engines are queried together, exactly like the browser
+build mixes `memory` with Web Storage:
+
+```javascript
+await db.query(`
+  CREATE TABLE Cache (id INTEGER) ENGINE = memory;
+  CREATE TABLE Docs (id INTEGER) ENGINE = scratch;
+
+  SELECT * FROM Cache JOIN Docs;
+`);
+```
+
+`removeEngine` only unregisters an engine; the data it owns is left untouched,
+so registering the same backend again brings its tables back. The default
+engine cannot be removed - point `setDefaultEngine` at another engine first.
+
+Unknown keys in an engine config are rejected, so a misspelled option fails
+loudly instead of quietly falling back to a default.
 
 ## License
 

--- a/gluesql.node.js
+++ b/gluesql.node.js
@@ -1,13 +1,37 @@
 const native = require('./gluesql.native.js');
 
-function gluesql() {
+function gluesql(options = {}) {
+  const { engines = {}, defaultEngine } = options;
   const db = native.gluesql();
+
+  for (const [name, config] of Object.entries(engines)) {
+    db.addEngine(name, config);
+  }
+
+  if (defaultEngine !== undefined) {
+    db.setDefaultEngine(defaultEngine);
+  }
 
   return {
     async query(sql) {
       return JSON.parse(db.query(sql));
     },
+    addEngine(name, config) {
+      db.addEngine(name, config);
+    },
+    removeEngine(name) {
+      db.removeEngine(name);
+    },
+    listEngines() {
+      return db.listEngines();
+    },
+    defaultEngine() {
+      return db.defaultEngine();
+    },
+    setDefaultEngine(name) {
+      db.setDefaultEngine(name);
+    },
   };
 }
 
-module.exports = { gluesql };
+module.exports = { gluesql, storages: native.storages };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build:web": "wasm-pack build --no-pack --target web --no-typescript --release --out-dir ./dist_web",
     "build:opfs": "wasm-pack build --no-pack --target web --no-typescript --release --out-dir ./dist_opfs -- --features opfs",
     "build:node": "napi build --release --platform --js gluesql.native.js --dts gluesql.native.d.ts --no-default-features --features nodejs",
-    "test:node": "node tests/nodejs.js",
+    "build:node:full": "napi build --release --platform --js gluesql.native.js --dts gluesql.native.d.ts --no-default-features --features full",
+    "test:node": "node --test \"tests/node/*.test.js\"",
     "test:browser": "playwright test"
   },
   "repository": {
@@ -42,6 +43,9 @@
     "url": "https://github.com/gluesql/gluesql-js/issues"
   },
   "homepage": "https://gluesql.org/docs",
+  "engines": {
+    "node": ">=22"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,14 +1,19 @@
+mod engines;
+mod storage;
+
 use {
     crate::payload::convert,
+    engines::Engines,
     gluesql_core::prelude::Glue as CoreGlue,
-    gluesql_memory_storage::MemoryStorage,
-    napi::{Error, Result, Status},
+    napi::{Error, Result},
     napi_derive::napi,
+    serde_json::Value as Json,
+    storage::StorageConfig,
 };
 
 #[napi]
 pub struct Glue {
-    inner: CoreGlue<MemoryStorage>,
+    inner: CoreGlue<Engines>,
 }
 
 impl Default for Glue {
@@ -22,19 +27,58 @@ impl Glue {
     #[napi(constructor)]
     pub fn new() -> Self {
         Self {
-            inner: CoreGlue::new(MemoryStorage::default()),
+            inner: CoreGlue::new(Engines::default()),
         }
+    }
+
+    /// Registers a storage backend under `engine`, which is then usable as the
+    /// `ENGINE` clause value of `CREATE TABLE`.
+    #[napi(ts_args_type = "engine: string, config: Record<string, unknown>")]
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn add_engine(&mut self, engine: String, config: Json) -> Result<()> {
+        let config = StorageConfig::parse(config).map_err(to_napi_error)?;
+
+        self.inner
+            .storage
+            .add(engine, config)
+            .map_err(to_napi_error)
+    }
+
+    /// Unregisters a storage backend. Tables of the removed engine become
+    /// unreachable, but their data is left untouched.
+    #[napi]
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn remove_engine(&mut self, engine: String) -> Result<()> {
+        self.inner.storage.remove(&engine).map_err(to_napi_error)
+    }
+
+    /// Registered engine names, sorted alphabetically.
+    #[napi]
+    pub fn list_engines(&self) -> Vec<String> {
+        self.inner.storage.names()
+    }
+
+    /// Engine used when `CREATE TABLE` omits the `ENGINE` clause.
+    #[napi]
+    pub fn default_engine(&self) -> Option<String> {
+        self.inner.storage.default_engine()
+    }
+
+    #[napi]
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn set_default_engine(&mut self, engine: String) -> Result<()> {
+        self.inner
+            .storage
+            .set_default(engine)
+            .map_err(to_napi_error)
     }
 
     #[napi]
     #[allow(clippy::needless_pass_by_value)]
     pub fn query(&mut self, sql: String) -> Result<String> {
-        let payloads = self
-            .inner
-            .execute(sql)
-            .map_err(|error| to_napi_error(&error))?;
+        let payloads = self.inner.execute(sql).map_err(to_napi_error)?;
 
-        serde_json::to_string(&convert(payloads)).map_err(|error| to_napi_error(&error))
+        serde_json::to_string(&convert(payloads)).map_err(to_napi_error)
     }
 }
 
@@ -44,6 +88,14 @@ pub fn gluesql() -> Glue {
     Glue::new()
 }
 
-fn to_napi_error(error: &impl ToString) -> Error {
-    Error::new(Status::GenericFailure, error.to_string())
+/// Storage backends this build was compiled with, sorted alphabetically.
+#[napi]
+#[allow(dead_code)]
+pub fn storages() -> Vec<String> {
+    storage::storages()
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn to_napi_error(error: impl ToString) -> Error {
+    Error::from_reason(error.to_string())
 }

--- a/src/node/engines.rs
+++ b/src/node/engines.rs
@@ -1,0 +1,316 @@
+use {
+    crate::node::storage::StorageConfig,
+    gluesql_core::{
+        data::{CustomFunction as StructCustomFunction, Key, Schema, Value},
+        error::{Error, Result},
+        store::{
+            AlterTable, CustomFunction, CustomFunctionMut, GStore, GStoreMut, Index, IndexMut,
+            MetaIter, Metadata, Planner, RowIter, Store, StoreMut, Transaction,
+        },
+    },
+    gluesql_memory_storage::MemoryStorage,
+    std::collections::{BTreeMap, HashMap},
+};
+
+/// Engine registered when a [`Glue`](super::Glue) instance is created.
+pub const DEFAULT_ENGINE: &str = "memory";
+
+/// Object-safe view of a storage backend.
+pub trait Engine: GStore + GStoreMut {}
+impl<T: GStore + GStoreMut> Engine for T {}
+
+/// Named storage backends of one database instance.
+///
+/// Statements are routed to the backend that owns the table: the engine named
+/// by the `ENGINE` clause when the table is created, and afterwards whichever
+/// backend actually holds the schema. Ownership is not read back from
+/// `Schema::engine`, because several storages drop that field when they reload
+/// a schema from disk.
+pub struct Engines {
+    storages: BTreeMap<String, Box<dyn Engine>>,
+    default_engine: Option<String>,
+    functions: HashMap<String, StructCustomFunction>,
+}
+
+impl Default for Engines {
+    fn default() -> Self {
+        Self {
+            storages: BTreeMap::from([(
+                DEFAULT_ENGINE.to_owned(),
+                Box::new(MemoryStorage::default()) as Box<dyn Engine>,
+            )]),
+            default_engine: Some(DEFAULT_ENGINE.to_owned()),
+            functions: HashMap::new(),
+        }
+    }
+}
+
+impl Engines {
+    /// Registers a backend under `engine`. The name is what the `ENGINE` clause
+    /// of `CREATE TABLE` refers to.
+    pub fn add(&mut self, engine: String, config: StorageConfig) -> Result<()> {
+        if !is_identifier(&engine) {
+            return Err(Error::StorageMsg(format!(
+                "invalid engine name: {engine:?} (the ENGINE clause only accepts letters, digits and underscores)"
+            )));
+        }
+
+        if self.storages.contains_key(&engine) {
+            return Err(Error::StorageMsg(format!(
+                "engine already exists: {engine} (remove it first to replace)"
+            )));
+        }
+
+        self.storages.insert(engine, config.open()?);
+
+        Ok(())
+    }
+
+    /// Unregisters a backend, leaving the data it owns untouched.
+    pub fn remove(&mut self, engine: &str) -> Result<()> {
+        if self.default_engine.as_deref() == Some(engine) {
+            return Err(Error::StorageMsg(format!(
+                "cannot remove the default engine: {engine} (call setDefaultEngine first)"
+            )));
+        }
+
+        self.storages
+            .remove(engine)
+            .map(|_| ())
+            .ok_or_else(|| self.not_found(engine))
+    }
+
+    /// Registered engine names, sorted alphabetically.
+    pub fn names(&self) -> Vec<String> {
+        self.storages.keys().cloned().collect()
+    }
+
+    pub fn default_engine(&self) -> Option<String> {
+        self.default_engine.clone()
+    }
+
+    pub fn set_default(&mut self, engine: String) -> Result<()> {
+        if !self.storages.contains_key(&engine) {
+            return Err(self.not_found(&engine));
+        }
+
+        self.default_engine = Some(engine);
+
+        Ok(())
+    }
+
+    fn not_found(&self, engine: &str) -> Error {
+        Error::StorageMsg(format!(
+            "engine not found: {engine} (registered: {})",
+            self.storages
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    }
+
+    /// Engine holding `table_name`, falling back to the default engine for
+    /// tables that do not exist yet.
+    fn engine_of(&self, table_name: &str) -> Result<&str> {
+        for (engine, storage) in &self.storages {
+            if storage.fetch_schema(table_name)?.is_some() {
+                return Ok(engine);
+            }
+        }
+
+        self.default_engine
+            .as_deref()
+            .ok_or_else(|| Error::StorageMsg(format!("engine not found for table: {table_name}")))
+    }
+
+    fn storage_of(&self, table_name: &str) -> Result<&dyn Engine> {
+        let engine = self.engine_of(table_name)?;
+
+        self.storages
+            .get(engine)
+            .map(Box::as_ref)
+            .ok_or_else(|| Self::missing_storage(table_name))
+    }
+
+    fn storage_of_mut(&mut self, table_name: &str) -> Result<&mut Box<dyn Engine>> {
+        let engine = self.engine_of(table_name)?.to_owned();
+
+        self.storages
+            .get_mut(&engine)
+            .ok_or_else(|| Self::missing_storage(table_name))
+    }
+
+    fn missing_storage(table_name: &str) -> Error {
+        Error::StorageMsg(format!("storage not found for table: {table_name}"))
+    }
+}
+
+/// Names that cannot appear in an `ENGINE` clause are rejected on
+/// registration; they would produce an engine no statement can reach.
+fn is_identifier(engine: &str) -> bool {
+    let mut chars = engine.chars();
+
+    chars
+        .next()
+        .is_some_and(|first| first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|char| char.is_ascii_alphanumeric() || char == '_')
+}
+
+impl Store for Engines {
+    fn fetch_schema(&self, table_name: &str) -> Result<Option<Schema>> {
+        for (engine, storage) in &self.storages {
+            if let Some(schema) = storage.fetch_schema(table_name)? {
+                return Ok(Some(Schema {
+                    engine: Some(engine.clone()),
+                    ..schema
+                }));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn fetch_all_schemas(&self) -> Result<Vec<Schema>> {
+        let mut schemas = Vec::new();
+
+        for (engine, storage) in &self.storages {
+            for schema in storage.fetch_all_schemas()? {
+                schemas.push(Schema {
+                    engine: Some(engine.clone()),
+                    ..schema
+                });
+            }
+        }
+
+        schemas.sort_by(|a, b| a.table_name.cmp(&b.table_name));
+
+        Ok(schemas)
+    }
+
+    fn fetch_data(&self, table_name: &str, key: &Key) -> Result<Option<Vec<Value>>> {
+        self.storage_of(table_name)?.fetch_data(table_name, key)
+    }
+
+    fn scan_data<'a>(&'a self, table_name: &str) -> Result<RowIter<'a>> {
+        self.storage_of(table_name)?.scan_data(table_name)
+    }
+}
+
+impl StoreMut for Engines {
+    fn insert_schema(&mut self, schema: &Schema) -> Result<()> {
+        let engine = schema
+            .engine
+            .clone()
+            .or_else(|| self.default_engine.clone())
+            .ok_or_else(|| {
+                Error::StorageMsg(format!("engine not found for table: {}", schema.table_name))
+            })?;
+
+        let schema = Schema {
+            engine: Some(engine.clone()),
+            ..schema.clone()
+        };
+
+        self.storages
+            .get_mut(&engine)
+            .ok_or_else(|| Self::missing_storage(&schema.table_name))?
+            .insert_schema(&schema)
+    }
+
+    fn delete_schema(&mut self, table_name: &str) -> Result<()> {
+        self.storage_of_mut(table_name)?.delete_schema(table_name)
+    }
+
+    fn append_data(&mut self, table_name: &str, rows: Vec<Vec<Value>>) -> Result<()> {
+        self.storage_of_mut(table_name)?
+            .append_data(table_name, rows)
+    }
+
+    fn insert_data(&mut self, table_name: &str, rows: Vec<(Key, Vec<Value>)>) -> Result<()> {
+        self.storage_of_mut(table_name)?
+            .insert_data(table_name, rows)
+    }
+
+    fn delete_data(&mut self, table_name: &str, keys: Vec<Key>) -> Result<()> {
+        self.storage_of_mut(table_name)?
+            .delete_data(table_name, keys)
+    }
+}
+
+impl Transaction for Engines {
+    fn begin(&mut self, autocommit: bool) -> Result<bool> {
+        if !autocommit {
+            return Err(Error::StorageMsg(
+                "explicit transactions are not supported when engines are combined".to_owned(),
+            ));
+        }
+
+        for storage in self.storages.values_mut() {
+            storage.begin(autocommit)?;
+        }
+
+        Ok(true)
+    }
+
+    fn rollback(&mut self) -> Result<()> {
+        for storage in self.storages.values_mut() {
+            storage.rollback()?;
+        }
+
+        Ok(())
+    }
+
+    fn commit(&mut self) -> Result<()> {
+        for storage in self.storages.values_mut() {
+            storage.commit()?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Metadata for Engines {
+    fn scan_table_meta(&self) -> Result<MetaIter> {
+        let mut metas = Vec::new();
+
+        for storage in self.storages.values() {
+            for meta in storage.scan_table_meta()? {
+                metas.push(meta?);
+            }
+        }
+
+        metas.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        Ok(Box::new(metas.into_iter().map(Ok)))
+    }
+}
+
+impl CustomFunction for Engines {
+    fn fetch_function<'a>(&'a self, func_name: &str) -> Result<Option<&'a StructCustomFunction>> {
+        Ok(self.functions.get(&func_name.to_uppercase()))
+    }
+
+    fn fetch_all_functions(&self) -> Result<Vec<&StructCustomFunction>> {
+        Ok(self.functions.values().collect())
+    }
+}
+
+impl CustomFunctionMut for Engines {
+    fn insert_function(&mut self, func: StructCustomFunction) -> Result<()> {
+        self.functions.insert(func.func_name.to_uppercase(), func);
+
+        Ok(())
+    }
+
+    fn delete_function(&mut self, func_name: &str) -> Result<()> {
+        self.functions.remove(&func_name.to_uppercase());
+
+        Ok(())
+    }
+}
+
+impl AlterTable for Engines {}
+impl Index for Engines {}
+impl IndexMut for Engines {}
+impl Planner for Engines {}

--- a/src/node/storage.rs
+++ b/src/node/storage.rs
@@ -1,0 +1,52 @@
+use {
+    crate::node::engines::Engine,
+    gluesql_core::error::{Error, Result},
+    gluesql_memory_storage::MemoryStorage,
+    serde::Deserialize,
+    serde_json::Value as Json,
+};
+
+/// Backends compiled into this build, sorted alphabetically.
+///
+/// Each backend is a cargo feature, so a build only carries what it was asked
+/// for. `storages()` is what tells JavaScript which ones are available.
+pub fn storages() -> Vec<String> {
+    let mut storages = vec!["memory"];
+
+    storages.sort_unstable();
+
+    storages.into_iter().map(str::to_owned).collect()
+}
+
+/// Storage backend descriptor coming from JavaScript.
+///
+/// The `storage` field selects the backend and every backend specific option
+/// lives in the same object:
+///
+/// ```javascript
+/// db.addEngine('scratch', { storage: 'memory' });
+/// ```
+///
+/// Unknown keys are rejected: a misspelled option would otherwise be dropped
+/// silently and hand back a backend configured with defaults. A backend that
+/// this build was not compiled with is reported as an unknown `storage` value.
+#[derive(Deserialize)]
+#[serde(tag = "storage", rename_all = "camelCase", deny_unknown_fields)]
+pub enum StorageConfig {
+    Memory {},
+}
+
+impl StorageConfig {
+    pub fn parse(config: Json) -> Result<Self> {
+        serde_json::from_value(config)
+            .map_err(|error| Error::StorageMsg(format!("invalid storage config: {error}")))
+    }
+
+    // Infallible when the build carries no backend but `memory`.
+    #[allow(clippy::unnecessary_wraps)]
+    pub fn open(self) -> Result<Box<dyn Engine>> {
+        match self {
+            Self::Memory {} => Ok(Box::new(MemoryStorage::default())),
+        }
+    }
+}

--- a/tests/node/engines.test.js
+++ b/tests/node/engines.test.js
@@ -1,0 +1,207 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const { gluesql, storages } = require('../../gluesql.node.js');
+
+test('starts with the in-memory engine as default', () => {
+  const db = gluesql();
+
+  assert.deepEqual(db.listEngines(), ['memory']);
+  assert.equal(db.defaultEngine(), 'memory');
+});
+
+test('registers engines declaratively', () => {
+  const db = gluesql({
+    engines: { scratch: { storage: 'memory' } },
+    defaultEngine: 'scratch',
+  });
+
+  assert.deepEqual(db.listEngines(), ['memory', 'scratch']);
+  assert.equal(db.defaultEngine(), 'scratch');
+});
+
+test('the default engine owns tables created without an ENGINE clause', async () => {
+  const db = gluesql({
+    engines: { scratch: { storage: 'memory' } },
+    defaultEngine: 'scratch',
+  });
+
+  await db.query(`
+    CREATE TABLE Implicit (id INTEGER);
+    CREATE TABLE Explicit (id INTEGER) ENGINE = memory;
+  `);
+
+  db.setDefaultEngine('memory');
+  db.removeEngine('scratch');
+
+  // `Implicit` lived in the removed engine, `Explicit` did not.
+  await assert.rejects(
+    () => db.query('SELECT * FROM Implicit'),
+    /table not found: Implicit/,
+  );
+  assert.deepEqual(await db.query('SELECT * FROM Explicit'), [
+    { type: 'SELECT', rows: [] },
+  ]);
+});
+
+test('routes tables by the ENGINE clause and joins across engines', async () => {
+  const db = gluesql();
+  db.addEngine('scratch', { storage: 'memory' });
+
+  await db.query(`
+    CREATE TABLE Main (mid INTEGER) ENGINE = memory;
+    CREATE TABLE Scratch (sid INTEGER) ENGINE = scratch;
+    INSERT INTO Main VALUES (1), (2);
+    INSERT INTO Scratch VALUES (10);
+  `);
+
+  assert.deepEqual(await db.query('SELECT mid, sid FROM Main JOIN Scratch'), [
+    {
+      type: 'SELECT',
+      rows: [
+        { mid: 1, sid: 10 },
+        { mid: 2, sid: 10 },
+      ],
+    },
+  ]);
+});
+
+test('SHOW TABLES lists the tables of every engine', async () => {
+  const db = gluesql();
+  db.addEngine('scratch', { storage: 'memory' });
+
+  await db.query(`
+    CREATE TABLE Cached (id INTEGER) ENGINE = memory;
+    CREATE TABLE Scratch (id INTEGER) ENGINE = scratch;
+  `);
+
+  assert.deepEqual(await db.query('SHOW TABLES'), [
+    { type: 'SHOW TABLES', tables: ['Cached', 'Scratch'] },
+  ]);
+
+  db.removeEngine('scratch');
+
+  assert.deepEqual(await db.query('SHOW TABLES'), [
+    { type: 'SHOW TABLES', tables: ['Cached'] },
+  ]);
+});
+
+test('removed engines drop out of the registry', async () => {
+  const db = gluesql();
+  db.addEngine('scratch', { storage: 'memory' });
+  await db.query('CREATE TABLE Foo (id INTEGER) ENGINE = scratch');
+
+  db.removeEngine('scratch');
+
+  assert.deepEqual(db.listEngines(), ['memory']);
+  await assert.rejects(
+    () => db.query('SELECT * FROM Foo'),
+    /table not found: Foo/,
+  );
+});
+
+test('keeps the default engine registered', () => {
+  const db = gluesql({ engines: { scratch: { storage: 'memory' } } });
+
+  assert.throws(
+    () => db.removeEngine('memory'),
+    /cannot remove the default engine: memory \(call setDefaultEngine first\)/,
+  );
+
+  db.setDefaultEngine('scratch');
+  db.removeEngine('memory');
+
+  assert.deepEqual(db.listEngines(), ['scratch']);
+  assert.equal(db.defaultEngine(), 'scratch');
+});
+
+test('rejects unknown engines and duplicated names', () => {
+  const db = gluesql();
+
+  assert.throws(
+    () => db.addEngine('scratch', { storage: 'nope' }),
+    /invalid storage config: unknown variant `nope`/,
+  );
+  assert.throws(
+    () => db.addEngine('memory', { storage: 'memory' }),
+    /engine already exists: memory/,
+  );
+  assert.throws(
+    () => db.setDefaultEngine('scratch'),
+    /engine not found: scratch \(registered: memory\)/,
+  );
+  assert.throws(() => db.removeEngine('scratch'), /engine not found: scratch/);
+});
+
+test('rejects engine names no ENGINE clause could reach', () => {
+  const db = gluesql();
+
+  for (const name of ['', '  ', 'my-db', '1st', 'a b']) {
+    assert.throws(
+      () => db.addEngine(name, { storage: 'memory' }),
+      /invalid engine name/,
+      `expected ${JSON.stringify(name)} to be rejected`,
+    );
+  }
+
+  db.addEngine('my_db2', { storage: 'memory' });
+
+  assert.deepEqual(db.listEngines(), ['memory', 'my_db2']);
+});
+
+test('rejects misspelled and misplaced config options', () => {
+  const db = gluesql();
+
+  // Would silently hand back a differently configured engine if unknown keys
+  // were dropped.
+  assert.throws(
+    () => db.addEngine('disk', { storage: 'memory', path: './data' }),
+    /invalid storage config: unknown field `path`/,
+  );
+});
+
+test('supports custom functions', async () => {
+  const db = gluesql();
+
+  await db.query('CREATE FUNCTION add_one (n INT) RETURN n + 1');
+
+  assert.deepEqual(await db.query('SELECT add_one(1) AS value'), [
+    { type: 'SELECT', rows: [{ value: 2 }] },
+  ]);
+  assert.deepEqual(await db.query('SHOW FUNCTIONS'), [
+    { type: 'SHOW FUNCTIONS', functions: ['add_one(n: INT)'] },
+  ]);
+
+  await db.query('DROP FUNCTION add_one');
+
+  await assert.rejects(
+    () => db.query('SELECT add_one(1) AS value'),
+    /unsupported function: ADD_ONE/,
+  );
+});
+
+test('reports table metadata of every engine', async () => {
+  const db = gluesql();
+  db.addEngine('scratch', { storage: 'memory' });
+
+  await db.query(`
+    CREATE TABLE Cached (id INTEGER) ENGINE = memory;
+    CREATE TABLE Scratch (id INTEGER) ENGINE = scratch;
+  `);
+
+  const [{ rows }] = await db.query(
+    'SELECT OBJECT_NAME, CREATED FROM GLUE_OBJECTS ORDER BY OBJECT_NAME',
+  );
+
+  assert.deepEqual(
+    rows.map(({ OBJECT_NAME }) => OBJECT_NAME),
+    ['Cached', 'Scratch'],
+  );
+  assert.match(rows[0].CREATED, /^\d{4}-\d{2}-\d{2} /);
+});
+
+test('reports the backends this build carries', () => {
+  const compiled = storages();
+
+  assert.deepEqual(compiled, [...compiled].sort());
+  assert.ok(compiled.includes('memory'), 'every build carries the memory backend');
+});

--- a/tests/node/query.test.js
+++ b/tests/node/query.test.js
@@ -1,7 +1,8 @@
 const assert = require('node:assert/strict');
-const { gluesql } = require('../gluesql.node.js');
+const { test } = require('node:test');
+const { gluesql } = require('../../gluesql.node.js');
 
-async function main() {
+test('executes multiple statements in one query', async () => {
   const db = gluesql();
 
   assert.deepEqual(
@@ -24,11 +25,13 @@ async function main() {
       ],
     },
   ]);
+});
+
+test('rejects with the storage error message', async () => {
+  const db = gluesql();
 
   await assert.rejects(
     () => db.query('SELECT * FROM Missing'),
     /fetch: table not found: Missing/,
   );
-}
-
-main();
+});

--- a/tests/node/support.js
+++ b/tests/node/support.js
@@ -1,0 +1,70 @@
+const fs = require('node:fs');
+const net = require('node:net');
+const os = require('node:os');
+const path = require('node:path');
+const { storages } = require('../../gluesql.node.js');
+
+/// Creates a temporary directory that is removed when the test finishes.
+function tempDir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gluesql-node-'));
+
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  return dir;
+}
+
+/// Path of a not-yet-existing file inside a temporary directory.
+function tempPath(t, name) {
+  return path.join(tempDir(t), name);
+}
+
+function reachable({ host, port, timeout = 500 }) {
+  return new Promise((resolve) => {
+    const socket = net
+      .connect({ host, port })
+      .setTimeout(timeout)
+      .on('connect', () => {
+        socket.destroy();
+        resolve(true);
+      })
+      .on('timeout', () => {
+        socket.destroy();
+        resolve(false);
+      })
+      .on('error', () => resolve(false));
+  });
+}
+
+/// Skips a test when this build was not compiled with the backend. Optional
+/// backends (parquet, redis, mongo) are cargo features, so `npm run test:node`
+/// stays green on a default build and the `full` build is what covers them.
+function requireStorage(t, name) {
+  if (storages().includes(name)) {
+    return true;
+  }
+
+  t.skip(`build without the ${name} storage`);
+
+  return false;
+}
+
+/// Skips a test when the server is down, unless GLUESQL_TEST_REQUIRE_SERVICES
+/// is set: CI sets it so that an unreachable service fails the job instead of
+/// silently reporting success.
+async function requireServer(t, { name, host, port }) {
+  if (await reachable({ host, port })) {
+    return true;
+  }
+
+  const message = `no ${name} server on ${host}:${port}`;
+
+  if (process.env.GLUESQL_TEST_REQUIRE_SERVICES) {
+    throw new Error(message);
+  }
+
+  t.skip(message);
+
+  return false;
+}
+
+module.exports = { tempDir, tempPath, requireStorage, requireServer };


### PR DESCRIPTION
Node.js currently gets a single `MemoryStorage`, so nothing survives the process. This adds the piece every persistent backend needs: an engine registry, exposed to JavaScript, that routes statements to whichever backend owns the table.

This is the first of a series; it deliberately adds **no** new storage backend. `memory` is still the only engine, so the diff is the routing model and its contract, not seven dependencies. The backends follow one PR each (redb, json, csv, file, then the opt-in parquet/redis/mongo).

## What it looks like

```javascript
const { gluesql, storages } = require('gluesql');

const db = gluesql({
  engines: { scratch: { storage: 'memory' } },
  defaultEngine: 'scratch',
});

db.addEngine('another', { storage: 'memory' });
db.listEngines();      // ['another', 'memory', 'scratch']
db.defaultEngine();    // 'scratch'
db.removeEngine('another');
storages();            // ['memory'] — what this build was compiled with
```

Engine names are what the `ENGINE` clause refers to, so tables from different engines join through the same SQL interface, exactly like the browser build mixes `memory` with Web Storage.

## Why not `CompositeStorage`

The browser build multiplexes with `gluesql-composite-storage`, and the obvious move was to reuse it here. I did that first and backed it out, for three reasons.

**1. It routes by `Schema::engine`, which storages are free to lose.** `JsonStorage::fetch_schema` hardcodes `engine: None` even though the `.sql` file on disk records `ENGINE = <name>`, so a JSON engine that is not the composite default never receives writes — rows land in the default engine, `INSERT` reports `affected: 1`, no error, and the following `SELECT` returns nothing. `ParquetStorage` and `MongoStorage` hardcode it the same way. Reproduced on 0.20.0 and on gluesql `main`; the composite test suite only covers memory-only and memory+redb, and redb happens to round-trip the field because it serializes the whole `Schema`.

`Engines` therefore resolves ownership by asking each backend whether it holds the table, and stamps the resolved engine name into the schemas it hands out. That cannot be forged by a backend that drops the field.

**2. It regresses `CREATE FUNCTION`.** `MemoryStorage` implements `CustomFunction`/`CustomFunctionMut`; `CompositeStorage` takes the erroring trait defaults. Swapping the storage type turns working SQL into `[Storage] CustomFunction is not supported`, and `GLUE_OBJECTS.CREATED` into `NULL` for the same reason (`Metadata` default). Verified against a build of `main`:

```
main:       CREATE FUNCTION add_one → ok, SELECT add_one(1) → 2, GLUE_OBJECTS.CREATED → timestamp
composite:  storage: [Storage] CustomFunction is not supported
```

`Engines` holds the function definitions itself and merges each backend's table metadata, so both keep working.

**3. `SHOW TABLES` becomes nondeterministic.** `CompositeStorage` iterates a `HashMap`; `Engines` keeps a `BTreeMap` and sorts schemas by table name.

The cost is ~150 lines of routing that mirror `CompositeStorage`'s own logic, and one dependency fewer on the native target. The wasm build keeps using `CompositeStorage` and is untouched.

## Contract choices worth a look

- **Config objects reject unknown keys.** `{ storage: 'memory', path: './data' }` fails instead of quietly handing back a volatile engine. Serde needs the braced `Memory {}` variant for this to hold on unit variants.
- **Engine names must be usable in SQL.** `addEngine('my-db', …)` and `addEngine('', …)` are rejected; both would register an engine no `ENGINE` clause can reach.
- **The default engine cannot be removed.** `CompositeStorage::remove` silently clears it, leaving `defaultEngine() === null` and a later `CREATE TABLE` failing with an error that names the table rather than the missing default. Call `setDefaultEngine` first.
- **`removeEngine` drops the backend, releasing its resources.** That is how an exclusive file lock is released, which the redb PR relies on.
- **Backends are cargo features from the start.** `nodejs` selects the shipped set and `full` selects everything; `storages()` reports what a build carries. Nothing is gated yet because nothing else exists yet, but the following PRs slot in without reshaping this one.

## Verification

- `npm run test:node` → 15/15. The suite moves to `node --test` so each backend can add its own spec file; `tests/nodejs.js` becomes `tests/node/query.test.js` unchanged in substance.
- Specs cover: default-engine routing proven by removal (the table disappears, an `ENGINE = memory` table does not), cross-engine JOIN, `SHOW TABLES` aggregation and shrink, custom functions including `DROP FUNCTION`, `GLUE_OBJECTS` metadata, and every rejection listed above.
- `cargo fmt --all --check`, `cargo clippy -p gluesql-js --no-default-features --features nodejs --locked --all-targets`, `cargo clippy --workspace --target wasm32-unknown-unknown --locked --all-targets`, `cargo check -p gluesql-js --features opfs --target wasm32-unknown-unknown --locked` all clean.
- `npm run build:web` and `npm run build:opfs` still succeed.

## Follow-up

The `engine: None` behaviour above is worth reporting upstream in `gluesql/gluesql`; this PR does not depend on it being fixed, since routing no longer trusts the field.
